### PR TITLE
minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ html
 dist
 MANIFEST
 *.o
+.project
+.pydevproject
+.settings
 Untitled*.ipynb
 Untitled*.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
+
 python:
   - 2.6
   - 2.7
+
 script:
     - python setup.py build_ext -i
     - nosetests

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
    :target: https://travis-ci.org/iminuit/iminuit
 
 iminuit
---------
+-------
 
 Interactive IPython Friendly Mimizer based on `SEAL Minuit <http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/release/download.html>`_.
 (It's included in the package no need to install it separately)
@@ -52,7 +52,7 @@ All the tutorials are in tutorial directory. You can view it online too.
 Documentation
 -------------
 
-http://iminuit.github.com/iminuit/
+http://iminuit.github.io/iminuit/
 
 Technical Stuff
 ---------------

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -7,7 +7,7 @@ Full API Documentation
 
 Quick Summary
 -------------
-These are the things you will use a lot.
+These are the things you will use a lot:
 
 .. autosummary::
     util.describe
@@ -122,8 +122,8 @@ fitarguments.
     :members:
     :undoc-members:
 
-Return Value Struct:
---------------------
+Return Value Struct
+-------------------
 
 iminuit uses various structs as return value. This section lists the struct
 and all it's field
@@ -307,5 +307,5 @@ Function Signature Extraction Ordering
     .. note::
 
         If you are unsure what minuit will parse your function signature as
-        , you can use :func:`describe` which returns tuple of arument names
+        , you can use :func:`describe` which returns tuple of argument names
         minuit will use as call signature.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,7 @@ release = iminuit.info.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', '_themes']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,28 +1,29 @@
 iminuit
-========
+=======
 
-Interactive IPython Friendly Mimizer based on `SEAL Minuit <http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/>`_.
-(It's included in the package no need to install it separately)
+Interactive IPython-friendly Mimizer based on `SEAL Minuit <http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/>`_.
+(It's included in the package, no need to install it separately)
 
 It is designed from ground up to be fast, interactive and cython friendly. iminuit
 extract function signature very permissively starting from checking *func_code*
-down to last resort of parsing docstring(or you could tell iminuit to stop looking
+down to last resort of parsing docstring (or you could tell iminuit to stop looking
 and take your answer). The interface is inspired heavily
 by PyMinuit and the status printout is inspired by ROOT Minuit. iminuit is
-mostly compatible with PyMinuit(with few exceptions). Existing PyMinuit
+mostly compatible with PyMinuit (with few exceptions). Existing PyMinuit
 code can be ported to iminuit by just changing the import statement.
 
-In a nutshell,::
+In a nutshell::
 
     from iminuit import Minuit
-    def f(x,y,z):
-        return (x-2)**2 + (y-3)**2 + (z-4)**2
+    def f(x, y, z):
+        return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
     m = Minuit(f)
     m.migrad()
-    print m.values #{'x':2,'y':3,'z':4}
-    print m.errors
+    print(m.values)  # {'x': 2,'y': 3,'z': 4}
+    print(m.errors)  # {'x': 1,'y': 1,'z': 1}
 
-If you are interested in fitting a curve/distribution, take a look at `probfit <http://iminuit.github.com/probfit/>`_. 
+If you are interested in fitting a curve or distribution, take a look at
+`probfit <http://iminuit.github.io/probfit/>`_. 
 
 .. _lcg-minuit: http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/
 .. _PyMinuit: http://code.google.com/p/pyminuit/
@@ -42,7 +43,7 @@ Download and Install
 
     pip install iminuit
 
-You can find our repository at `github <https://github.com/iminuit/iminuit>`_.
+You can find our repository at `github <https://github.com/iminuit/iminuit>`_:
 
 ::
 
@@ -51,13 +52,13 @@ You can find our repository at `github <https://github.com/iminuit/iminuit>`_.
 Tutorial
 --------
 
-All the tutorials are in tutorial directory. You can view it online too.
+All the tutorials are in tutorial directory. You can view them online too:
 
 - `Quick start <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/iminuit/master/tutorial/tutorial.ipynb>`_
 - `Hard Core Cython tutorial <http://nbviewer.ipython.org/urls/raw.github.com/iminuit/iminuit/master/tutorial/hard-core-tutorial.ipynb>`_.
-  If you need to do a huge likelihood fit that need speed.
-  This is for you. If you don't care, just use `probfit <http://iminuit.github.com/probfit/>`_. It's a fun
-  read though I think.
+  If you need to do a huge likelihood fit that needs speed, this is for you.
+  If you don't care, just use `probfit <http://iminuit.github.io/probfit/>`_.
+  It's a fun read though I think.
 
 
 API

--- a/iminuit/util.py
+++ b/iminuit/util.py
@@ -33,9 +33,10 @@ class Struct:
 def arguments_from_docstring(doc):
     """Parse first line of docstring for argument name
 
-    Docstring should be of the form 'min(iterable[, key=func])\n'.
+    Docstring should be of the form ``min(iterable[, key=func])``.
+
     It can also parse cython docstring of the form
-    Minuit.migrad(self[, int ncall_me =10000, resume=True, int nsplit=1])
+    ``Minuit.migrad(self[, int ncall_me =10000, resume=True, int nsplit=1])``
     """
     if doc is None:
         raise RuntimeError('__doc__ is None')

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=''.join(open('README.rst').readlines()[4:]),
     author='Piti Ongmongkolkul',
     author_email='piti118@gmail.com',
-    url='https://piti118.github.com/iminuit',
+    url='http://iminuit.github.io/iminuit/',
     download_url='http://pypi.python.org/packages/source/i/'
             'iminuit/iminuit-%s.tar.gz' % __version__,
     package_dir={'iminuit': 'iminuit'},

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -1736,7 +1736,7 @@
      "collapsed": false,
      "input": [
       "#this is very useful if you want to build a generic cost functor\n",
-      "#this is actually how dist_fit is implemented\n",
+      "#this is actually how probfit is implemented\n",
       "from iminuit.util import make_func_code\n",
       "x = [1,2,3,4,5]\n",
       "y = [2,4,6,8,10]# y=2x\n",

--- a/tutorial/tutorial.py
+++ b/tutorial/tutorial.py
@@ -306,7 +306,7 @@ from iminuit import Minuit, describe, Struct
 # <codecell>
 
 #this is very useful if you want to build a generic cost functor
-#this is actually how dist_fit is implemented
+#this is actually how probfit is implemented
 from iminuit.util import make_func_code
 x = [1,2,3,4,5]
 y = [2,4,6,8,10]# y=2x


### PR DESCRIPTION
Some minor cleanup.
The only important thing is the change of `url` in setup.py, I think:

```
-    url='https://piti118.github.com/iminuit',
+    url='http://iminuit.github.io/iminuit/',
```

@piti118 At the moment both of these docs pages are outdated:
- http://iminuit.github.io/iminuit/
  - http://piti118.github.io/iminuit/
    (they have the typo `m.migrads()` instead of `m.migrad()` on the front page)

After merging this, can you update http://iminuit.github.io/iminuit/ and push again to https://pypi.python.org/pypi/iminuit/ which still points to the outdated (Home Page: https://piti118.github.com/iminuit )?

And remove http://piti118.github.io/iminuit/ and http://piti118.github.io/dist_fit/ to avoid confusion?
