### PR TITLE
Clarify the double licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,3 +22,13 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+Note:
+MIT license is GPL compatible, so it is an acceptable license for a wrapper,
+as can be seen here:
+http://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLWrapper
+http://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#OrigBSD
+
+(L)GPL can be combined or included in code that does not impose more restrictive
+conditions.


### PR DESCRIPTION
There has been a few emails in the Scipy mailing list, when someone questioned if a wrapper on a GPL library could be licensed as something else.

The bottomline is that it is fine, but it leads to confusion, so I have added a small clarification in case someone else gets confused.

http://mail.scipy.org/pipermail/scipy-user/2014-February/035435.html
