### PR TITLE
Add Cython to coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 omit = */py23_compat.py
+plugins = Cython.Coverage
 [report]
 exclude_lines =
     pragma: no cover
@@ -9,4 +10,3 @@ exclude_lines =
     __repr__
     __getitem__
     raise RuntimeError
-

--- a/iminuit/_libiminuit.pyx
+++ b/iminuit/_libiminuit.pyx
@@ -1,3 +1,5 @@
+# cython: linetrace=True, binding=True
+# distutils: define_macros=CYTHON_TRACE=1
 # cython: embedsignature=True, c_string_type=str, c_string_encoding=ascii
 # distutils: language = c++
 """IPython Minuit class definition.


### PR DESCRIPTION
Now that coverage 4.0 and Cython 0.23 is out it should be easy to get coverage reports for Cython files:

http://blog.behnel.de/posts/coverage-analysis-for-cython-modules.html

This would be very nice to have for iminuit, because the core code is 1300 lines of Cython in `iminuit/_libiminuit.pyx`.
