### PR TITLE
Add Python 3.6 runtime test to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,13 @@ matrix:
       script:
         source ci-scripts/travis_sdist_test.sh
 
+    - name: "3.6: sdist"
+      python: 3.6
+      install:
+        pip install --upgrade cython numpy
+      script:
+        source ci-scripts/travis_sdist_test.sh
+
     - name: "3.7: sdist"
       python: 3.7-dev
       install:


### PR DESCRIPTION
Add Python 3.6 runtime to the Travis CI testing suite.