### PR TITLE
Remove unsupported Travis sudo API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,13 @@ matrix:
       script:
         source ci-scripts/travis_sdist_test.sh
 
+    - name: "3.6: sdist"
+      python: 3.6
+      install:
+        pip install --upgrade cython numpy
+      script:
+        source ci-scripts/travis_sdist_test.sh
+
     - name: "3.7: sdist"
       python: 3.7-dev
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-sudo: false
-
 cache:
   pip: true
   directories:


### PR DESCRIPTION
# Description

This PR drops the use of the unsupported Travis `sudo` API. In [November 2018 Traivs announced they would be retiring the 'sudo' API](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

> If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.