### PR TITLE
Adding azure

### DIFF
--- a/.ci/azure-build-pipeline.yml
+++ b/.ci/azure-build-pipeline.yml
@@ -1,0 +1,104 @@
+trigger:
+  tags:
+    include:
+    - v*
+
+pr:
+- master
+
+
+# Required variables (set in UI):
+#   package_name:     This is the output name, - is replaced by _
+#   many_linux_base:  Should be quay.io/pypa/manylinux1_ or skhep/manylinuxgcc-
+variables:
+  package_name: iminuit
+  many_linux_base: quay.io/pypa/manylinux1_
+
+jobs:
+
+- job: LinuxSDist
+  pool:
+    vmImage: 'ubuntu-16.04'
+  variables:
+    python.architecture: 'none'
+  steps:
+    - script: |
+        python -m pip install setuptools cython
+        python setup.py sdist
+      displayName: Publish sdist
+    - template: azure-publish-dist.yml
+
+- job: ManyLinux
+  strategy:
+    matrix:
+      64Bit2010:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        image: quay.io/pypa/manylinux2010_x86_64
+        python.architecture: x64
+      64Bit:
+        arch: x86_64
+        plat: manylinux1_x86_64
+        image: $(many_linux_base)x86_64
+        python.architecture: x64
+      32Bit:
+        arch: i686
+        plat: manylinux1_i686
+        image: $(many_linux_base)i686
+        python.architecture: x86
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - script: |
+        docker run -e NPY_NUM_BUILD_JOBS=4 -e PLAT=$(plat) -e package_name=$(package_name) --rm -v `pwd`:/io $(image) /io/.ci/build-wheels.sh
+        ls -lh wheelhouse/
+        mkdir -p dist
+        cp wheelhouse/$(package_name)*.whl dist/.
+      displayName: Build wheels
+    - template: azure-publish-dist.yml
+
+- job: macOS
+  variables:
+    python.architecture: 'x64'
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+  pool:
+    vmImage: 'macOS-10.14'
+  steps:
+    - template: azure-setup.yml
+    - template: azure-steps.yml
+    - template: azure-publish-dist.yml
+
+- job: Windows
+  strategy:
+    matrix:
+      Python27:
+        python.version: '2.7'
+        python.architecture: 'x64'
+      Python36:
+        python.version: '3.6'
+        python.architecture: 'x64'
+      Python37:
+        python.version: '3.7'
+        python.architecture: 'x64'
+      Python27_32:
+        python.version: '2.7'
+        python.architecture: 'x86'
+      Python36_32:
+        python.version: '3.6'
+        python.architecture: 'x86'
+      Python37_32:
+        python.version: '3.7'
+        python.architecture: 'x86'
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+    - template: azure-setup.yml
+    - template: azure-steps.yml
+    - template: azure-publish-dist.yml

--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -1,0 +1,9 @@
+
+steps:
+- task: PublishPipelineArtifact@0
+  inputs:
+    artifactName: '$(Agent.OS)_$(Agent.JobName)_$(python.architecture)'
+    targetPath: 'dist'
+
+# You can set FULLBUILD_FORCE to anything non-blank to get the manylinux job to run.
+# Artifacts are attached to the build, and are published with an Azure release pipeline.

--- a/.ci/azure-setup.yml
+++ b/.ci/azure-setup.yml
@@ -1,0 +1,22 @@
+# This is special for macOS because "UsePythonVersion"
+# does not use the official Python.org installers.
+
+steps:
+
+- script: .ci/macos-install-python.sh '$(python.version)'
+  displayName: Install Python.org Python
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin')) 
+
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+    architecture: '$(python.architecture)'
+  condition: and(succeeded(), ne(variables['Agent.OS'], 'Darwin')) 
+
+- script: |
+    mkdir -p dist
+    python -m pip install --upgrade pip
+    python -m pip install --upgrade pytest wheel twine setuptools
+    python -m pip install -r dev-requirements.txt
+  displayName: 'Install dependencies'
+

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -1,0 +1,42 @@
+steps:
+
+- script: |
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" $(python.architecture)
+    set MSSdk=1
+    set DISTUTILS_USE_SDK=1
+    python -m pip wheel . -w wheelhouse/
+  displayName: 'Build wheel (Windows Python 2.7)'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['python.version'], '2.7')) 
+
+- script: |
+    python -m pip wheel . -w wheelhouse/
+  displayName: 'Build wheel'
+  condition: and(succeeded(), not(and(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['python.version'], '2.7'))))
+
+- script: |
+    ls -lh wheelhouse
+    mkdir -p dist
+    cp wheelhouse/$(package_name)* dist/.
+  displayName: 'Show wheelhouse'
+
+- script: |
+    python -m pip install $(package_name) --no-index -f wheelhouse
+  displayName: 'Install wheel'
+
+- script: |
+    python -m pytest --pyargs iminuit --junitxml=junit/test-results.xml
+  # I'm selecting a random directory to not trigger relative imports.
+  workingDirectory: tutorial
+  displayName: 'Test with pytest'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/test-*.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'
+  condition: succeededOrFailed()
+
+- script: |
+    python -m pip install delocate
+    /Library/Frameworks/Python.framework/Versions/$(python.version)/bin/delocate-wheel dist/$(package_name)*.whl
+  displayName: 'Delocate wheels'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin')) 

--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e -x
+
+# Collect the pythons
+pys=(/opt/python/*/bin)
+
+# Filter out Python 3.4
+pys=(${pys[@]//*34*/})
+
+# Compile wheels
+for PYBIN in "${pys[@]}"; do
+    "${PYBIN}/pip" install -r /io/dev-requirements.txt
+    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/$package_name-*.whl; do
+    auditwheel repair --plat $PLAT "$whl" -w /io/wheelhouse/
+done
+
+# Install packages and test
+for PYBIN in "${pys[@]}"; do
+    "${PYBIN}/python" -m pip install $package_name --no-index -f /io/wheelhouse
+    "${PYBIN}/pytest" /io/tests
+done

--- a/.ci/macos-install-python.sh
+++ b/.ci/macos-install-python.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+PYTHON_VERSION="$1"
+
+case $PYTHON_VERSION in
+2.7)
+  FULL_VERSION=2.7.16
+  ;;
+3.6)
+  FULL_VERSION=3.6.8
+  ;;
+3.7)
+  FULL_VERSION=3.7.3
+  ;;
+esac
+
+INSTALLER_NAME=python-$FULL_VERSION-macosx10.9.pkg
+URL=https://www.python.org/ftp/python/$FULL_VERSION/$INSTALLER_NAME
+
+PY_PREFIX=/Library/Frameworks/Python.framework/Versions
+
+set -e -x
+
+curl $URL > $INSTALLER_NAME
+
+sudo installer -pkg $INSTALLER_NAME -target /
+
+sudo rm /usr/local/bin/python
+sudo ln -s /usr/local/bin/python$PYTHON_VERSION /usr/local/bin/python
+
+which python
+python --version
+python -m ensurepip
+python -m pip install setuptools twine wheel numpy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,10 @@
+numpy
+scipy
+
+cython
+
+pytest
+pytest-cov
+pylint
+flake8
+pydocstyle


### PR DESCRIPTION
This adds an Azure pipeline build, producing wheels and an sdist (with latest Cython). I'll need to set up the release pipeline as well to send these to PyPI, but that's entirely external. It will also be a manual step for now, rather than happening automatically on release tags. See the latest build here: https://dev.azure.com/scikit-hep/iMinuit/_build/results?buildId=786 . Closes #334 .

Minor cleanup on Travis (Python 3.7 was released, for example). The GammaPy test won't pass yet, obviously. PyTest integration and testing was slightly adjusted for consistency.