### PR TITLE
Better pytest integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+testpaths=iminuit
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # CFLAGS="-O0" python setup.py ... to override for debugging
 
 import os
+import sys
 import platform
 from os.path import dirname, join, exists
 from glob import glob
@@ -11,6 +12,9 @@ from distutils.ccompiler import CCompiler
 from distutils.unixccompiler import UnixCCompiler
 from distutils.msvccompiler import MSVCCompiler
 import distutils.ccompiler
+
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 # turn off warnings raised by Minuit and generated Cython code that need
 # to be fixed in the original code bases of Minuit and Cython
@@ -141,7 +145,8 @@ setup(
                  'iminuit/iminuit-%s.tar.gz' % __version__,
     packages=['iminuit', 'iminuit.tests'],
     ext_modules=extensions,
-    install_requires=['setuptools', 'numpy'],
+    install_requires=['numpy'],
+    setup_requires = [] + pytest_runner,
     extras_require={
         'tests': ['pytest', 'cython', 'matplotlib', 'scipy'],
     },


### PR DESCRIPTION
This adds the [recommended method](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner) of integrating PyTest with setup.py.

It also drops the redundant 'setuptools' from install_requires; setuptools must be available already for the file to run at all; PEP 518's `pyproject.toml` is the only way to change what happens before setup.py runs (and only for pip).