### PR TITLE
Travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 
 cache:
   pip: true
@@ -9,7 +10,7 @@ matrix:
   include:
     # remove "-dev" once 3.7 proper exists on travis-ci
     - name: "3.7: test, doc, coverage"
-      python: 3.7-dev
+      python: 3.7
       install:
         pip install --upgrade cython numpy pytest matplotlib scipy ipython sphinx sphinx_rtd_theme jupyter pytest-cov codecov
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
   only:
   - master
   - develop
-  - /^v\d/
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 dist: xenial
 
+# Only build main branches and tags/branches starting with a v and a digit
+branches:
+  only:
+  - master
+  - develop
+  - /^v\d/
+
 cache:
   pip: true
   directories:


### PR DESCRIPTION
iMinuit is still using the pre-release Python 3.7 on Travis. This moves to the current architecture for Travis before Trusty is phased out. This is needed for 3.7 and the default [changes next week anyway](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment).

I'm also removing the double Travis build on PRs by checking for main branches only. This is already set up this way with Appveyor.