### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ except ImportError:
     numpy_header = []
 
 libiminuit = Extension('iminuit._libiminuit',
-                       sources=(glob(join(cwd, 'iminuit/*' + ext)) + minuit_src),
+                       sources=sorted(glob(join(cwd, 'iminuit/*' + ext)) + minuit_src),
                        include_dirs=minuit_header + numpy_header,
                        define_macros=[('WARNINGMSG', '1')])
 extensions = [libiminuit]


### PR DESCRIPTION
Sort input file list
so that `_libiminuit.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.