### PR TITLE
Add Binder support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@
 .. image:: https://readthedocs.org/projects/iminuit/badge/?version=latest
    :target: https://iminuit.readthedocs.io/en/develop/?badge=latest
    :alt: Documentation Status
+.. image:: https://mybinder.org/badge_logo.svg
+  :target: https://mybinder.org/v2/gh/scikit-hep/iminuit/develop?filepath=tutorial
 
 .. skip-marker-do-not-remove
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,2 @@
+python -m pip install --upgrade -r requirements-dev.txt
+python -m pip install .

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,4 @@ ignore =
     requirements-dev.txt
     extern/Minuit2/.git
     iminuit/_libiminuit.cpp
+    binder/**


### PR DESCRIPTION
Resolves #396 

Requires PR #398 to go in first.

Add [Binder](https://mybinder.org/) support by using the [`postBuild`](https://mybinder.readthedocs.io/en/latest/config_files.html#postbuild-run-code-after-installing-the-environment) configuration file to install the required dependencies of `requirements-dev.txt` and then install `iminuit` itself from source. Additionally, add a launch Binder badge to the README that launches into the `tutorial` directory.

 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/scikit-hep/iminuit/docs/add-Binder-support?filepath=tutorial)