### PR TITLE
fix: Use check-manifest v0.42 directory ignore pattern

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,14 +6,12 @@ test=pytest
 
 [check-manifest]
 ignore =
-    .ci
-    .ci/*
+    .ci/**
     .appveyor.yml
     .coveragerc
     .gitmodules
     Makefile
-    doc
-    doc/*
+    doc/**
     environment-dev.yml
     requirements-dev.txt
     extern/Minuit2/.git


### PR DESCRIPTION
Use the new directory ignore pattern of `check-manifest` introduced in [`v0.42`](https://github.com/mgedmin/check-manifest/blob/master/CHANGES.rst#042-2020-05-03).

> You can ignore directories only by ignoring every file inside it. You can use `--ignore=dir/**` to do that

This fixes the issue in CI that has been seen in the [Azure Pipelines](https://dev.azure.com/scikit-hep/iMinuit/_build?definitionId=10&_a=summary) since the `check-manifest` `v0.42` release.