### PR TITLE
Add numba to yml file

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,6 +10,7 @@ name: iminuit-dev
 dependencies:
   - python==3.6
   - numpy
+  - numba
   - scipy
   - ipython
   - matplotlib


### PR DESCRIPTION
This package is a requisite. It is present in requirements-dev.txt, but not in environment-dev.yml.
It is needed by two tutorial tests to run.