### PR TITLE
Fix describe for wrapped functions

### DIFF
--- a/src/iminuit/tests/test_describe.py
+++ b/src/iminuit/tests/test_describe.py
@@ -122,6 +122,7 @@ def test_decorated_function():
         @wraps(f)
         def decorated(*args, **kwargs):
             return f(*args, **kwargs)
+
         return decorated
 
     @dummy_decorator
@@ -136,6 +137,6 @@ def test_decorated_function():
     def kw_only(x, *, y, z):
         pass
 
-    assert describe( one_arg) == list("x")
+    assert describe(one_arg) == list("x")
     assert describe(many_arg) == list("xyzt")
-    assert describe( kw_only) == list("xyz")
+    assert describe(kw_only) == list("xyz")

--- a/src/iminuit/tests/test_describe.py
+++ b/src/iminuit/tests/test_describe.py
@@ -3,6 +3,7 @@ from math import ldexp
 import sys
 import pytest
 import platform
+from functools import wraps
 
 is_pypy = platform.python_implementation() == "PyPy"
 
@@ -114,3 +115,27 @@ def test_generic_functor_with_fake_func():
             return a + b
 
     assert describe(A(), True) == ["x", "y"]
+
+
+def test_decorated_function():
+    def dummy_decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            return f(*args, **kwargs)
+        return decorated
+
+    @dummy_decorator
+    def one_arg(x):
+        pass
+
+    @dummy_decorator
+    def many_arg(x, y, z, t):
+        pass
+
+    @dummy_decorator
+    def kw_only(x, *, y, z):
+        pass
+
+    assert describe( one_arg) == list("x")
+    assert describe(many_arg) == list("xyzt")
+    assert describe( kw_only) == list("xyz")

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -373,8 +373,10 @@ def arguments_from_inspect(f):
     ok = True
     for name, par in signature.parameters.items():
         # Variable number of arguments is not supported
-        if par.kind is inspect.Parameter.VAR_POSITIONAL: ok = False
-        if par.kind is inspect.Parameter.VAR_KEYWORD   : ok = False
+        if par.kind is inspect.Parameter.VAR_POSITIONAL:
+            ok = False
+        if par.kind is inspect.Parameter.VAR_KEYWORD:
+            ok = False
     return ok, list(signature.parameters)
 
 
@@ -418,8 +420,10 @@ def describe(f, verbose=False):
     if ok:
         return args
     if verbose:
-        print("Failed to parse inspect.signature(f). Perhaps you are using"
-              " a variable number of arguments. This is not supported.")
+        print(
+            "Failed to parse inspect.signature(f). Perhaps you are using"
+            " a variable number of arguments. This is not supported."
+        )
 
     raise TypeError("Unable to obtain function signature")
 


### PR DESCRIPTION
Following #463, this PR introduces a fix to `describe` in order to recognize the signature of wrapped functions.