### PR TITLE
make iterate configurable

### DIFF
--- a/src/iminuit/tests/test_iminuit.py
+++ b/src/iminuit/tests/test_iminuit.py
@@ -1151,11 +1151,12 @@ def test_parameter_at_limit(sign):
     assert m.fmin.has_parameters_at_limit is False
 
 
-def test_inaccurate_fcn():
+@pytest.mark.parametrize("iterate,valid", ((1, False), (5, True)))
+def test_inaccurate_fcn(iterate, valid):
     def f(x):
         return abs(x) ** 10 + 1e7
 
     m = Minuit(f, x=2, errordef=1)
-    m.migrad()
-    assert m.valid
-    assert m.values["x"] == approx(0, abs=0.5)
+    m.migrad(iterate=iterate)
+    print(m.fmin)
+    assert m.valid == valid

--- a/src/iminuit/tests/test_iminuit.py
+++ b/src/iminuit/tests/test_iminuit.py
@@ -1158,5 +1158,4 @@ def test_inaccurate_fcn(iterate, valid):
 
     m = Minuit(f, x=2, errordef=1)
     m.migrad(iterate=iterate)
-    print(m.fmin)
     assert m.valid == valid


### PR DESCRIPTION
@matthewfeickert @kratsg This patch makes the iteration ("try hard") feature of iminuit configurable. You should definitely try to play with the precision keyword, too, because I did and it improve convergence when the cost function has low precision (the doc string was extended to better explain what this setting does).