### PR TITLE
style: pyupgrade

### DIFF
--- a/.ci/install_pypy36.py
+++ b/.ci/install_pypy36.py
@@ -10,7 +10,7 @@ if Path("pypy36/pypy3/bin/activate").exists():
     raise SystemExit
 
 plat = {"darwin": "osx64", "linux": "linux64"}[sys.platform]
-filename = "pypy3.6-v7.3.1-{}.tar.bz2".format(plat)
+filename = f"pypy3.6-v7.3.1-{plat}.tar.bz2"
 
 url = "https://bitbucket.org/pypy/pypy/downloads/"
 plat = {"darwin": "osx64", "linux": "linux64"}[sys.platform]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
   hooks:
   - id: black
 
+# Check for some common issues
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.8.4
   hooks:
@@ -51,8 +52,19 @@ repos:
     types: [file]
     files: (\.cmake|CMakeLists.txt)(.in)?$
 
+# Notebook formatting
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.4.0
+  rev: 0.4.1
   hooks:
   - id: nbqa-black
     additional_dependencies: [black==20.8b1]
+  - id: nbqa-pyupgrade
+    additional_dependencies: [pyupgrade==2.7.4]
+    args: ["--py36-plus"]
+
+# Keep Python syntax up to date
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.7.4
+  hooks:
+  - id: pyupgrade
+    args: ["--py36-plus"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # iminuit documentation build configuration file, created by
 # sphinx-quickstart on Tue Nov 13 10:50:10 2012.
@@ -65,8 +64,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"iminuit"
-copyright = u"2020, Piti Ongmongkolkul and the iminuit team"
+project = "iminuit"
+copyright = "2020, Piti Ongmongkolkul and the iminuit team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -186,7 +185,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "iminuit.tex", u"iminuit Documentation", u"Piti Ongmongkolkul", "manual")
+    ("index", "iminuit.tex", "iminuit Documentation", "Piti Ongmongkolkul", "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -214,7 +213,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "iminuit", u"iminuit Documentation", [u"Piti Ongmongkolkul"], 1)]
+man_pages = [("index", "iminuit", "iminuit Documentation", ["Piti Ongmongkolkul"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -229,8 +228,8 @@ texinfo_documents = [
     (
         "index",
         "iminuit",
-        u"iminuit Documentation",
-        u"Piti Ongmongkolkul",
+        "iminuit Documentation",
+        "Piti Ongmongkolkul",
         "iminuit",
         "One line description of project.",
         "Miscellaneous",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pathlib import Path
 from cmake import CMakeExtension, CMakeBuild
 from setuptools import setup

--- a/src/iminuit/_deprecated.py
+++ b/src/iminuit/_deprecated.py
@@ -1,14 +1,14 @@
 import warnings
 
 
-class deprecated(object):
+class deprecated:
     def __init__(self, reason):
         self._reason = reason
 
     def __call__(self, func):
         def decorated_func(*args, **kwargs):
             warnings.warn(
-                "{0} is deprecated: {1}".format(func.__name__, self._reason),
+                f"{func.__name__} is deprecated: {self._reason}",
                 category=DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/iminuit/_minuit.py
+++ b/src/iminuit/_minuit.py
@@ -793,7 +793,7 @@ class Minuit:
 
         if not self._fmin.is_valid:
             raise RuntimeError(
-                ("Function minimum is not valid. Make sure " "MIGRAD converged first")
+                "Function minimum is not valid. Make sure " "MIGRAD converged first"
             )
         if var is not None and var not in self._pos2var:
             raise RuntimeError(f"Unknown parameter {var}")
@@ -1139,9 +1139,11 @@ class Minuit:
 
         if text:
             plt.title(
-                ("%s = %.3g" % (vname, v))
+                (f"{vname} = {v:.3g}")
                 if vmin is None
-                else ("%s = %.3g - %.3g + %.3g" % (vname, v, v - vmin, vmax - v)),
+                else (
+                    "{} = {:.3g} - {:.3g} + {:.3g}".format(vname, v, v - vmin, vmax - v)
+                ),
                 fontsize="large",
             )
 
@@ -1452,9 +1454,9 @@ class BasicView:
         return len(self) == len(other) and all(x == y for x, y in zip(self, other))
 
     def __repr__(self):
-        s = "<%s of Minuit at %x>" % (self.__class__.__name__, id(self._minuit))
+        s = "<{} of Minuit at {:x}>".format(self.__class__.__name__, id(self._minuit))
         for (k, v) in zip(self._minuit._pos2var, self):
-            s += "\n  {0}: {1}".format(k, v)
+            s += f"\n  {k}: {v}"
         return s
 
 

--- a/src/iminuit/repr_html.py
+++ b/src/iminuit/repr_html.py
@@ -30,13 +30,13 @@ def tag(name, *args, **kwargs):
     head = "<" + name
     for k in sorted(kwargs):
         v = kwargs[k]
-        head += ' %s="%s"' % (k, v)
+        head += f' {k}="{v}"'
     head += ">"
     tail = "</%s>" % name
     if len(args) == 0:
         return [head + tail]
     if len(args) == 1 and isinstance(args[0], str):
-        return ["{0} {1} {2}".format(head, args[0], tail)]
+        return ["{} {} {}".format(head, args[0], tail)]
     return [head, *args, tail]
 
 


### PR DESCRIPTION
Trying out PyUpgrade to clean up older syntax to cleaner 3.6+. Idea from @kratsg & @matthewfeikert in https://github.com/scikit-hep/pyhf/pull/1164 .

Only the first commit is hand written - the second commit is entirely generated.

- style: add pyupgrade
- style: pre-commit run -a
