### PR TITLE
Remove globalcc

### DIFF
--- a/src/iminuit/_minuit.py
+++ b/src/iminuit/_minuit.py
@@ -313,15 +313,6 @@ class Minuit:
         return self.npar - sum(self.fixed)
 
     @property
-    def gcc(self):
-        """Global correlation coefficients (dict : name -> gcc)."""
-        free = self._free_parameters()
-        if self._last_state.has_globalcc:
-            gcc = self._last_state.globalcc
-            if gcc:
-                return {v: gcc[i] for i, v in enumerate(free)}
-
-    @property
     def fmin(self):
         """Current function minimum.
 

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -272,14 +272,6 @@ def test_covariance():
     assert c["x", "x"] == approx(1.0)
 
 
-def test_gcc():
-    m = Minuit(lambda x, y: (x - y) ** 2 + x ** 2, x=0, y=0)
-    assert m.gcc is None
-    m.errordef = 1
-    m.migrad()
-    assert_allclose([m.gcc["x"], m.gcc["y"]], np.sqrt((0.5, 0.5)))
-
-
 def test_array_func_1():
     m = Minuit(func_np, (2, 1))
     m.errors = (1, 1)


### PR DESCRIPTION
globalcc is the correlation of the internal covariance matrix, which is redundant at best and possibly misleading when parameters are limited