### PR TITLE
tests: include tests in SDist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include src/*.cpp
 include src/*.hpp
 include src/iminuit/*.py
+include tests/*.py
+include tests/*.txt
 recursive-include extern/root/math/minuit2/inc *.h
 recursive-include extern/root/math/minuit2/src *.cxx
 recursive-include extern/pybind11/include *.h


### PR DESCRIPTION
The SDist does not contain the tests. While the _wheel_ should not contain tests (and I didn't check to verify that by adding it, `/tests` is not picked up as a package or as package data, which you should do), it is helpful if the SDist contains tests, so you can build and then verify the build worked, say in conda-forge. I'll look at a different way to solve this on conda-forge, but this is a suggestion.

Edit: from a very quick check, it looks fine. It's rare to have `/src/<package>` based packages accidentally pick up `/tests` in the wheel.