### PR TITLE
use custom type_caster for std::vector

### DIFF
--- a/src/fcn.cpp
+++ b/src/fcn.cpp
@@ -3,11 +3,11 @@
 #include <Minuit2/MnPrint.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <cmath>
 #include <cstdint>
 #include <sstream>
 #include <vector>
+#include "type_caster.hpp"
 
 namespace py = pybind11;
 using namespace ROOT::Minuit2;

--- a/src/type_caster.hpp
+++ b/src/type_caster.hpp
@@ -1,0 +1,51 @@
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <vector>
+
+namespace pybind11 {
+namespace detail {
+
+template <typename Value>
+struct type_caster<std::vector<Value>> {
+  using vec_t = std::vector<Value>;
+  using value_conv = make_caster<Value>;
+  using size_conv = make_caster<std::size_t>;
+
+  bool load(handle src, bool convert) {
+    value.clear();
+    // TODO optimize for python objects that support buffer protocol
+    if (isinstance<iterable>(src)) {
+      auto seq = reinterpret_borrow<iterable>(src);
+      if (hasattr(seq, "__len__")) value.reserve(static_cast<std::size_t>(len(seq)));
+      for (auto it : seq) {
+        value_conv conv;
+        if (!conv.load(it, convert)) return false;
+        value.push_back(cast_op<Value&&>(std::move(conv)));
+      }
+      return true;
+    }
+    return false;
+  }
+
+public:
+  template <typename T>
+  static handle cast(T&& src, return_value_policy policy, handle parent) {
+    if (!std::is_lvalue_reference<T>::value)
+      policy = return_value_policy_override<Value>::policy(policy);
+    // TODO optimize by returning ndarray instead of list
+    list l(src.size());
+    size_t index = 0;
+    for (auto&& value : src) {
+      auto value_ = reinterpret_steal<object>(value_conv::cast(value, policy, parent));
+      if (!value_) return handle();
+      PyList_SET_ITEM(l.ptr(), (ssize_t)index++,
+                      value_.release().ptr()); // steals a reference
+    }
+    return l.release();
+  }
+
+  PYBIND11_TYPE_CASTER(vec_t, _("List[") + value_conv::name + _("]"));
+};
+
+} // namespace detail
+} // namespace pybind11

--- a/src/usercovariance.cpp
+++ b/src/usercovariance.cpp
@@ -1,9 +1,9 @@
 #include <Minuit2/MnUserCovariance.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include <vector>
 #include "equal.hpp"
+#include "type_caster.hpp"
 
 namespace ROOT {
 namespace Minuit2 {

--- a/src/userparameterstate.cpp
+++ b/src/userparameterstate.cpp
@@ -1,8 +1,8 @@
 #include <Minuit2/MnUserParameterState.h>
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 #include "equal.hpp"
+#include "type_caster.hpp"
 
 namespace ROOT {
 namespace Minuit2 {


### PR DESCRIPTION
A fix for https://github.com/scikit-hep/pyhf/pull/1208, but also allows us to convert more efficiently in the future