### PR TITLE
Fix/conda2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
+      - develop
     paths-ignore:
       - 'doc/**'
       - '.ci/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   pull_request:
     branches:
-      - develop
     paths-ignore:
       - 'doc/**'
       - '.ci/**'

--- a/cmake_ext.py
+++ b/cmake_ext.py
@@ -7,18 +7,14 @@ from pathlib import Path
 
 
 class CMakeExtension(Extension):
-    def __init__(self, sourcedir=""):
-        Extension.__init__(self, "CMakeExtension", sources=[])
+    def __init__(self, name, sourcedir=""):
+        Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
 
 class CMakeBuild(build_ext):
-    def run(self):
-        for ext in self.extensions:
-            self.build_extension(ext)
-
     def build_extension(self, ext):
-        extdir = Path(self.get_ext_fullpath(ext.name)).parent.absolute() / "iminuit"
+        extdir = Path(self.get_ext_fullpath(ext.name)).parent.absolute()
         # required for auto-detection of auxiliary "native" libs
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}/",
@@ -35,7 +31,7 @@ class CMakeBuild(build_ext):
         cmake_args += [f"-DCMAKE_BUILD_TYPE={cfg}"]
         build_args = ["--config", cfg]  # needed by some generators, e.g. on Windows
 
-        if self.compiler and self.compiler.compiler_type == "msvc":
+        if self.compiler.compiler_type == "msvc":
             # CMake allows an arch-in-generator style for backward compatibility
             contains_arch = any(x in cmake_generator for x in ("ARM", "Win64"))
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     version=version,
     python_requires=">=3.6",
     zip_safe=False,
-    ext_modules=[CMakeExtension()],
+    ext_modules=[CMakeExtension("iminuit._core")],
     cmdclass=dict(build_ext=CMakeBuild),
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Removes the overload to `run`, which was missing the setup steps, including initializing the compiler. Setuptools tries to copy the created final .so file from the build directory to the inplace directory when it's done - this was broken by the run not initializing correctly - so now the extension has to have the expected name - and if you use the full name, `iminuit._core`, setuptools handles the folder for you.