### PR TITLE
Fix iminuit.util.describe(callable) for partial functions without signature

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -874,7 +874,12 @@ def _arguments_from_docstring(obj):
     #   min(arg1, arg2, *args, *[, key=func]) -> value
     #   Foo.bar(self, int ncall_me =10000, [resume=True, int nsplit=1])
 
-    name = obj.__name__
+    try:
+        name = obj.__name__
+    except AttributeError:
+        # See Issue #608
+        # https://github.com/scikit-hep/iminuit/issues/608
+        return ()
 
     token = name + "("
     start = doc.find(token)

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -52,6 +52,16 @@ def test_generic_function():
     assert describe(f) == ()
 
 
+def test_generic_partial():
+    from functools import partial
+
+    def f(*args):
+        pass
+
+    partial_f = partial(f, 42, 12, 4)
+    assert describe(partial_f) == ()
+
+
 def test_generic_lambda():
     assert describe(lambda *args: 0) == ()
 

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -204,6 +204,7 @@ def test_Func2():
 
 def test_no_signature():
     from functools import partial
+
     def no_signature(*args):
         x, y = args
         return (x - 1) ** 2 + (y - 2) ** 2

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -203,6 +203,7 @@ def test_Func2():
 
 
 def test_no_signature():
+    from functools import partial
     def no_signature(*args):
         x, y = args
         return (x - 1) ** 2 + (y - 2) ** 2
@@ -212,6 +213,18 @@ def test_no_signature():
     m = Minuit(no_signature, 3, 4)
     assert m.values == (3, 4)
     assert m.parameters == ("x0", "x1")
+
+    partial_no_signature = partial(no_signature, 42)
+    m = Minuit(partial_no_signature, 3)
+    assert m.values == (3,)
+    assert m.parameters == ("x0",)
+    m.migrad()
+
+    lambda_no_signature = lambda *args: no_signature(42, *args)
+    m = Minuit(lambda_no_signature, 2)
+    assert m.values == (2,)
+    assert m.parameters == ("x0",)
+    m.migrad()
 
     m = Minuit(no_signature, x=1, y=2, name=("x", "y"))
     assert m.values == (1, 2)

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -221,8 +221,7 @@ def test_no_signature():
     assert m.parameters == ("x0",)
     m.migrad()
 
-    lambda_no_signature = lambda *args: no_signature(42, *args)
-    m = Minuit(lambda_no_signature, 2)
+    m = Minuit(lambda *args: no_signature(42, *args), 2)
     assert m.values == (2,)
     assert m.parameters == ("x0",)
     m.migrad()

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -203,8 +203,6 @@ def test_Func2():
 
 
 def test_no_signature():
-    from functools import partial
-
     def no_signature(*args):
         x, y = args
         return (x - 1) ** 2 + (y - 2) ** 2
@@ -214,17 +212,6 @@ def test_no_signature():
     m = Minuit(no_signature, 3, 4)
     assert m.values == (3, 4)
     assert m.parameters == ("x0", "x1")
-
-    partial_no_signature = partial(no_signature, 42)
-    m = Minuit(partial_no_signature, 3)
-    assert m.values == (3,)
-    assert m.parameters == ("x0",)
-    m.migrad()
-
-    m = Minuit(lambda *args: no_signature(42, *args), 2)
-    assert m.values == (2,)
-    assert m.parameters == ("x0",)
-    m.migrad()
 
     m = Minuit(no_signature, x=1, y=2, name=("x", "y"))
     assert m.values == (1, 2)


### PR DESCRIPTION
More information on this can be found in issue #608.

I'm happy for any feedback regarding the fix :)

Added some tests in both `tests/test_describe.py` as well as `tests/test_minuit.py`.