### PR TITLE
Port of merge_func_code functionality from probfit to iminuit

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,16 @@
 Changelog
 =========
 
+2.4.1 (March 6, 2021)
+---------------------
+
+New features
+~~~~~~~~~~~~
+- ``iminuit.user.merge_user_func``, ported from probfit, by @mbaak
+  This functionality makes it possible to merge function codes into compound objects,
+  allowing one to build more complex cost functions easily.
+  See for example ``tutorials/generic_least_squares_function.ipynb``.
+
 2.4.0 (February 10, 2021)
 -------------------------
 

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -962,3 +962,113 @@ def _address_of_cfunc(fcn):
     if isinstance(fcn, c_sig):
         return cast(fcn, c_void_p).value
     return 0
+
+
+def merge_func_code(
+    *arg, prefix=None, skip_first=False, factor_list=None, skip_prefix=None
+):
+    """
+    Merge function arguments.
+
+        def f(x,y,z): return do_something(x,y,z)
+        def g(x,z,p): return do_something(x,y,z)
+        fc, pos = merge_func_code(f,g)
+        #fc is now ('x','y','z','p')
+
+    Parameters
+    ----------
+        - **prefix** optional array of prefix string to add to each function
+          argument. Default None.::
+
+                def f(x,y,z): return do_something(x,y,z)
+                def g(x,z,p): return do_something(x,y,z)
+                fc, pos = merge_func_code(f,g,prefix=['f','g'], skip_first=True)
+                #fc now ('x','f_y','f_z','f_p')
+
+        - **skip_first** option boolean to skip prefixing the first argument
+          of each function. This should normally be true when prefix is not
+          None.
+
+        - **factor_list** option list of functions. For function that skip_first
+          should not be applied. The choice of prefix applice to factor_list
+          will be in the same order as prefix. Default None
+
+        - **skip_prefix** list of variable names that prefix should not be
+          applied to.
+
+    Returns
+    -------
+        tuple(Merged Func Code, position array)
+
+        position array **p[i][j]** indicates where in the argument list to
+        obtain argument **j** for functin **i**. If fact
+
+    .. seealso::
+
+        construct_arg
+    """
+    if prefix is not None and len(prefix) != len(arg):
+        raise ValueError(
+            "prefix should have the same length as number of ",
+            "functions. Expect %d(%r)" % (len(arg), arg),
+        )
+    all_arg = []
+    skip_prefix = set([]) if skip_prefix is None else set(skip_prefix)
+    for i, f in enumerate(arg):
+        tmp = []
+        first = skip_first
+        for vn in describe(f):
+            newv = vn
+            if not first and prefix is not None and newv not in skip_prefix:
+                newv = prefix[i] + newv
+            first = False
+            tmp.append(newv)
+        all_arg.append(tmp)
+
+    if factor_list is not None:
+        for i, f in enumerate(factor_list):
+            tmp = []
+            for vn in describe(f):
+                newv = vn
+                if prefix is not None and newv not in skip_prefix:
+                    newv = prefix[i] + newv
+                tmp.append(newv)
+            all_arg.append(tmp)
+
+    # now merge it
+    merge_arg = []
+    for a in all_arg:
+        for v in a:
+            if v not in merge_arg:
+                merge_arg.append(v)
+
+    # build the map list of numpy int array
+    pos = []
+    for a in all_arg:
+        tmp = []
+        for v in a:
+            tmp.append(merge_arg.index(v))
+        pos.append(np.array(tmp, dtype=np.int))
+    return Namespace(co_varnames=merge_arg, co_argcount=len(merge_arg)), pos
+
+
+def construct_arg(arg, fpos):
+    """
+    Pick a subset of arg.
+
+    Parameters
+    ----------
+    arg: tuple or function arguments
+        tuple or function arguments
+    fpos: array
+        array of positions, the subset to be picked up from arg
+
+    Returns
+    -------
+    subset of arg
+
+    .. seealso::
+        merge_func_code
+    """
+    arg = np.array(arg)
+    return tuple(arg[fpos])

--- a/src/iminuit/version.py
+++ b/src/iminuit/version.py
@@ -7,7 +7,7 @@
 # - Increase MAINTENANCE when fixing bugs without adding features
 # - During development, add suffix .devN with N >= 0
 # - For release candidates, add suffix .rcN with N >= 0
-iminuit_version = "2.4.0"
+iminuit_version = "2.4.1"
 
 # We list the corresponding ROOT version of the C++ Minuit2 library here
 root_version = "v6-23-01-RF-binSampling-685-ga642cc22e3"

--- a/tutorial/generic_least_squares_function.ipynb
+++ b/tutorial/generic_least_squares_function.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "from iminuit import Minuit\n",
-    "from iminuit.util import describe, make_func_code"
+    "from iminuit.util import describe, make_func_code, merge_func_code, construct_arg"
    ]
   },
   {
@@ -311,6 +311,78 @@
    "metadata": {},
    "source": [
     "It works :)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### merging complex models\n",
+    "\n",
+    "Let's say our model is complex, for example the product of two functions.\n",
+    "Here we show how to merge the function codes for such compound objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def linex(x, a, b):  # simple straight line model with explicit parameters\n",
+    "    return a + b * x\n",
+    "\n",
+    "def liney(y, c, d):  # simple straight line model with explicit parameters\n",
+    "    return c + d * y\n",
+    "\n",
+    "class ProductModel:\n",
+    "    \"\"\"\n",
+    "    product of two models\n",
+    "    \"\"\"\n",
+    "    def __init__(self, model1, model2):\n",
+    "        self.models = [model1, model2]\n",
+    "        self.func_code, self.argpos = merge_func_code(model1, model2)\n",
+    "\n",
+    "    def __call__(self, *arg):\n",
+    "        prod = 1.\n",
+    "        for i in range(2):\n",
+    "            func = self.models[i]\n",
+    "            # self.argpos contains the positions in arg to pick for each model \n",
+    "            # construct the arg for each model\n",
+    "            func_arg = construct_arg(arg, self.argpos[i])\n",
+    "            # call each model with the right argument\n",
+    "            func_value = func(*func_arg)\n",
+    "            prod *= func_value\n",
+    "\n",
+    "        return prod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prod = ProductModel(linex, liney)\n",
+    "describe(prod)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print (linex(1,1,1), liney(2,2,2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print (prod(1, 1, 1, 2, 2, 2))"
    ]
   }
  ],


### PR DESCRIPTION
Since probfit is depracated, it would make sense (imho) to include this useful bit of code 
here, just like decribe() and make_func_code().
It makes it much easier to construct cost functions from compound objects.

I have added an example to:
generic_least_squares_function.ipynb
