### PR TITLE
Fix: adjust limits in `draw_profile`

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1180,7 +1180,7 @@ class Minuit:
 
         if vmin is not None and band:
             # make sure not to increase the plots size if errors > axes limits
-            # do not change vmin, vmax as title should contain the uncertainties, not plot limits
+            # don't change vmin, vmax: title should contain the errors, not the plot limits
             axismin, axismax = fig.axes.get_xlim()
             spanmin = max(axismin, vmin)
             spanmax = min(axismax, vmax)

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1183,7 +1183,7 @@ class Minuit:
             # do not change vmin, vmax as title should contain the uncertainties, not plot limits
             axismin, axismax = fig.axes.get_xlim()
             spanmin = max(axismin, vmin)
-            spanmax = min(axinmax, vmax)
+            spanmax = min(axismax, vmax)
             plt.axvspan(spanmin, spanmax, facecolor="0.8")
 
         if text:

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1162,7 +1162,7 @@ class Minuit:
     def _draw_profile(self, vname, x, y, band, text):
         from matplotlib import pyplot as plt
 
-        fig, = plt.plot(x, y)
+        (fig,) = plt.plot(x, y)
         plt.xlabel(vname)
         plt.ylabel("FCN")
 

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1162,7 +1162,7 @@ class Minuit:
     def _draw_profile(self, vname, x, y, band, text):
         from matplotlib import pyplot as plt
 
-        plt.plot(x, y)
+        fig, = plt.plot(x, y)
         plt.xlabel(vname)
         plt.ylabel("FCN")
 
@@ -1179,7 +1179,12 @@ class Minuit:
             vmax = v + self.errors[vname]
 
         if vmin is not None and band:
-            plt.axvspan(vmin, vmax, facecolor="0.8")
+            # make sure not to increase the plots size if errors > axes limits
+            # do not change vmin, vmax as title should contain the uncertainties, not plot limits
+            axismin, axismax = fig.axes.get_xlim()
+            spanmin = max(axismin, vmin)
+            spanmax = min(axinmax, vmax)
+            plt.axvspan(spanmin, spanmax, facecolor="0.8")
 
         if text:
             plt.title(


### PR DESCRIPTION
Plotting the error as an area can expand the plot if the requested span is smaller than the errors.

Fixed by respecting the axes limits.