### PR TITLE
Add to_dict method to BasicView

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -79,6 +79,10 @@ class BasicView:
         s += ">"
         return s
 
+    def to_dict(self):
+        """Obtain dict representation"""
+        return dict(zip(self._minuit._pos2var, self))
+
 
 def _ndim(obj):
     nd = 0

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from . import _repr_html
 from . import _repr_text
 import numpy as np
+from typing import Dict
 
 inf = float("infinity")
 
@@ -79,7 +80,7 @@ class BasicView:
         s += ">"
         return s
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, float]:
         """Obtain dict representation"""
         return dict(zip(self._minuit._pos2var, self))
 

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -81,7 +81,7 @@ class BasicView:
         return s
 
     def to_dict(self) -> Dict[str, float]:
-        """Obtain dict representation"""
+        """Obtain dict representation."""
         return dict(zip(self._minuit._pos2var, self))
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,6 +71,12 @@ def test_ValueView():
     v[:"z"] = 2
     assert_equal(v, (2, 2, 3))
 
+    v_dict = v.to_dict()
+    assert isinstance(v_dict, dict)
+    assert v_dict['x'] == v['x']
+    assert v_dict['y'] == v['y']
+    assert v_dict['z'] == v['z']
+
 
 def test_Matrix():
     m = util.Matrix(("a", "b"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -73,9 +73,9 @@ def test_ValueView():
 
     v_dict = v.to_dict()
     assert isinstance(v_dict, dict)
-    assert v_dict['x'] == v['x']
-    assert v_dict['y'] == v['y']
-    assert v_dict['z'] == v['z']
+    assert v_dict["x"] == v["x"]
+    assert v_dict["y"] == v["y"]
+    assert v_dict["z"] == v["z"]
 
 
 def test_Matrix():


### PR DESCRIPTION
The new version of ValueView's `__iter__` now only iterates over the values, instead of keys & values. This is nice for converting to numpy arrays but removes the ability to convert to a dict with `dict(m0.values)`. This PR adds a `to_dict` method to `BasicView` to conveniently convert views to a dict.

Relevant historic discussion: https://github.com/scikit-hep/iminuit/issues/272#issuecomment-403433623