### PR TITLE
Create CostSum.signature_map

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -273,6 +273,36 @@ class CostSum(Cost, Sequence):
         """Get constituent cost function by index."""
         return self._items.__getitem__(key)
 
+    @property
+    def signature_map(self):
+        """
+        Access the signature map for the underlying Cost functions.
+
+        The values in the signature map represent the position of a parameter
+        in this CostSum's signature::
+
+            def f(x, a, b):
+                pass
+
+            def g(x, b, c):
+                pass
+
+            c_f = UnbinnedNLL(data_f, f)
+            c_g = UnbinnedNLL(data_g, g)
+            c_sum = c_f + c_g
+
+            assert c_sum.func_code.co_varnames == ('a', 'b', 'c')
+            assert c_sum.signature_map[0] == (0, 1)
+            assert c_sum.signature_map[1] == (1, 2)
+
+        Returns
+        -------
+        list
+            List of tuples. Each index of the list relates to the underlying
+            Cost function.
+        """
+        return self._maps
+
 
 class UnbinnedCost(MaskedCost):
     """Base class for unbinned cost functions."""

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -391,6 +391,22 @@ def test_addable_cost_3():
     assert cs((1, 1)) == pytest.approx(4.5)
 
 
+def test_cost_sum_signature_map():
+    def f(x, a, b):
+        pass
+
+    def g(x, b, c):
+        pass
+
+    c_f = UnbinnedNLL(None, f)
+    c_g = UnbinnedNLL(None, g)
+    c_sum = c_f + c_g
+
+    assert c_sum.func_code.co_varnames == ("a", "b", "c")
+    assert c_sum.signature_map[0] == (0, 1)
+    assert c_sum.signature_map[1] == (1, 2)
+
+
 def test_NormalConstraint_1():
     def model(x, a):
         return a


### PR DESCRIPTION
Enable public access to the CostSum._maps parameter, taking into account the comments in #624 