### PR TITLE
chore: pypa/cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: joerick/cibuildwheel@v1.8.0
+      - uses: pypa/cibuildwheel@v1.11.0
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Updating for the new location as part of the Python Packaging Authority!
