### PR TITLE
support float128 in builtin cost functions

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,11 @@ New features
 - ``util.FMin`` has new html/text representations; the field ``Valid parameters`` was
   removed, a title with the name of the minimisation method was added
 - ``Minuit.tol`` now accepts the values 0 and ``None``, the latter resets the default
+- Builtin cost functions now support models that return arrays in long double precision
+  ``float128``. In this case, all computations inside the cost function are also done in
+  higher precision.
+- Builtin cost functions now raise a warning if the user-defined model does not return
+  a numpy array
 
 Fixes
 ~~~~~

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -44,6 +44,10 @@ class HesseFailedWarning(IMinuitWarning):
     """HESSE failed warning."""
 
 
+class PerformanceWarning(UserWarning):
+    """Warning about performance issues."""
+
+
 class BasicView(abc.ABC):
     """
     Array-like view of parameter state.


### PR DESCRIPTION
Numba accelerated functions are now only called if the model returns arrays of type float32 or float64. The code falls back to Numpy for anything else.

Closes #658 