### PR TITLE
fixes for calling hesse and minos without existing function minimum

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,13 @@ Changelog
 
 2.7.0
 -----
+API change
+~~~~~~~~~~
+- If ``Minuit.hesse`` is called when ``Minuit.fmin`` is ``None``, an instance
+  ``Minuit.fmin`` is now created. If Hesse fails, the code does not raise an exception
+  anymore, since now the error state can be accessed as usual from the ``Minuit.fmin``
+  object. Users who relied on the exception should check ``Minuit.fmin`` from now on.
+
 New features
 ~~~~~~~~~~~~
 - ``Minuit.scipy`` can be used to minimise with SciPy algorithms. These may succeed
@@ -25,6 +32,10 @@ Fixes
   (patch submitted to ROOT)
 - ``Minuit.hesse`` no longer sets the status of the FunctionMinimum unconditionally
   to valid if it was invalid before
+- Repeated calls to ``Minuit.hesse`` no longer accumulate calls and eventually exhaust
+  the call limit, the call counter is now properly reset
+- Calling ``Minuit.minos`` repeatedly now does not recompute the Hessian and avoids
+  a bug that used to exhaust the call limit before in this case
 
 Documentation
 ~~~~~~~~~~~~~

--- a/src/hesse.cpp
+++ b/src/hesse.cpp
@@ -10,7 +10,8 @@ using namespace ROOT::Minuit2;
 
 void update_fmin(MnHesse& self, const FCNBase& fcn, FunctionMinimum& min,
                  unsigned maxcalls, float maxedm) {
-  MnUserFcn mfcn(fcn, min.UserState().Trafo(), min.NFcn());
+  // We reset call counter here in contrast to MnHesse.cxx:83
+  MnUserFcn mfcn(fcn, min.UserState().Trafo(), 0);
 
   // Run Hesse
   MinimumState st = self(mfcn, min.State(), min.UserState().Trafo(), maxcalls);
@@ -32,15 +33,6 @@ void bind_hesse(py::module m) {
   py::class_<MnHesse>(m, "MnHesse")
 
       .def(py::init<const MnStrategy&>())
-      // pybind11 needs help to figure out the return value that's why we use lambdas
-      .def(
-          "__call__",
-          [](MnHesse& self, const FCNBase& fcn, const MnUserParameterState& state,
-             unsigned maxcalls) -> MnUserParameterState {
-            return self(fcn, state, maxcalls);
-          },
-          py::keep_alive<1, 2>())
-
       .def("__call__", update_fmin)
 
       ;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -78,6 +78,13 @@ def test_MnUserParameterState():
     assert st[1].lower_limit == 1
     assert st[1].upper_limit == 4
 
+    st2 = MnUserParameterState(st)
+    assert st2 == st
+
+    st2.set_value(0, 1.1)
+
+    assert st2 != st
+
 
 def test_MnMigrad():
     fcn = FCN(fn, None, False, 1)

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1529,8 +1529,12 @@ def test_issue_643():
     m.migrad()
 
     m2 = Minuit(fcn, x=m.values["x"], y=m.values["y"], z=m.values["z"])
-    # this used to call MnHesse although it was not needed and quickly exhaust call limit
+    # used to call MnHesse when it was not needed and quickly exhaust call limit
     for i in range(10):
-        # m2.values[:] = (2, 3, 4)
         m2.minos()
-    # Call limit will still eventually become exhausted by calling Minos
+
+    m2.reset()
+    # used to exhaust call limit, because calls to MnHesse did not reset call count
+    for i in range(10):
+        m2.values = m.values
+        m2.minos()


### PR DESCRIPTION
Closes #631

This is a minor breaking change in the API.

If the user calls `Minuit.hesse` without an existing FunctionMinimum, a FunctionMinimum is now created. If MnHesse fails, we do not raise an exception anymore, since the information about the failure can be read from the `Minuit.fmin` attribute.