### PR TITLE
chore: add Apple Silicon wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,18 +8,28 @@ jobs:
     name: Build ${{ matrix.py }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         py: [cp36, cp37, cp38, cp39]
-      fail-fast: false
-    env:
-      CIBW_BUILD: ${{ matrix.py }}-*
+        arch: [auto]
+        include:
+          - os: macos-latest
+            py: cp38
+            arch: universal2
+          - os: macos-latest
+            py: cp39
+            arch: universal2
+
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
 
-      - uses: pypa/cibuildwheel@v2.0.0
+      - uses: pypa/cibuildwheel@v2.0.1
+        env:
+          CIBW_BUILD: ${{ matrix.py }}-*
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/cmake_ext.py
+++ b/cmake_ext.py
@@ -8,15 +8,6 @@ from setuptools import Extension
 from setuptools.command.build_ext import build_ext
 
 
-# Convert distutils Windows platform specifiers to CMake -A arguments
-PLAT_TO_CMAKE = {
-    "win32": "Win32",
-    "win-amd64": "x64",
-    "win-arm32": "ARM",
-    "win-arm64": "ARM64",
-}
-
-
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
@@ -51,7 +42,12 @@ class CMakeBuild(build_ext):
             # generator name.
             if not contains_arch:
                 # Convert distutils Windows platform specifiers to CMake -A arguments
-                arch = PLAT_TO_CMAKE[self.plat_name]
+                arch = {
+                    "win32": "Win32",
+                    "win-amd64": "x64",
+                    "win-arm32": "ARM",
+                    "win-arm64": "ARM64",
+                }[self.plat_name]
                 cmake_args += ["-A", arch]
 
             cmake_args += [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"]

--- a/cmake_ext.py
+++ b/cmake_ext.py
@@ -56,7 +56,7 @@ class CMakeBuild(build_ext):
             # Cross-compile support for macOS - respect ARCHFLAGS if set
             archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
             if archs:
-                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+                cmake_args += [f"-DCMAKE_OSX_ARCHITECTURES={';'.join(archs)}"]
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,13 @@
 Changelog
 =========
 
+2.8.1
+-----
+
+Other
+~~~~~
+- @henryiii added Silicon wheels
+
 2.8.0 (July 25, 2021)
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake",
-    "numpy"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -21,3 +20,4 @@ testpaths = [
 before-build = "python -m pip install numpy --only-binary=:all:"
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
+test-skip = ["*universal2:arm64"]

--- a/src/iminuit/version.py
+++ b/src/iminuit/version.py
@@ -7,7 +7,7 @@
 # - Increase MAINTENANCE when fixing bugs without adding features
 # - During development, add suffix .devN with N >= 0
 # - For release candidates, add suffix .rcN with N >= 0
-version = "2.8.0"
+version = "2.8.1"
 
 # We list the corresponding ROOT version of the C++ Minuit2 library here
 root_version = "v6-25-01-1694-g187368db19"


### PR DESCRIPTION
- chore: sync with cmake_example

I've made this look a bit more like `pybind/cmake_example` (and made `cmake_example` look a bit more like this in https://github.com/pybind/cmake_example/pull/53, as well) - the more this looks like the maintained example, the better. I've tried not to lose anything that was was an intentional change from that example, like the usage of ninja on Windows, etc. I've also kept f-strings and Paths, anything that was clearly an improvement over the original (and I think we are likely about to remove Python 2/3.5 from our examples, so likely it will look even more similar in the future).

@HDembenski, if you don't like any changes, I can roll back any of them expect the key change that allows Apple Silicon to be supported. :)

- ci: build Apple Silicon wheels

I've added a universal2 wheel build for the only Pythons supported on Apple Silicon; 3.8 and 3.9. I've also removed "NumPy" from the build requirements - I've checked, and you never include "numpy.h" (from NumPy), but only `pybind11/numpy.h`, which does not require NumPy during the build.
