### PR TITLE
chore: use PyPI package for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,8 @@ repos:
     files: src/iminuit/[^_].*\.py
 
 # C++ formatting
-- repo: git://github.com/doublify/pre-commit-clang-format
-  rev: 62302476d0da01515660132d76902359bed0f782
+- repo: https://github.com/ssciwr/clang-format-precommit
+  rev: v12.0.1
   hooks:
   - id: clang-format
 


### PR DESCRIPTION
The pip-installable PyPI package is 1-2 MB, and has cibuildwheel wheels for all major platforms. It allows exact pinning of pre-commit versions rather than depending on what you have installed locally, and works on pre-commit.ci, allowing automatic fixes. It also comes with a pre-commit hook.  See https://github.com/ssciwr/clang-format-wheel or https://twitter.com/HenrySchreiner3/status/1442877941910802433?s=20 for my announcement. Versions 10, 11, and 12 are available.