### PR TITLE
clang-format hook renamed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     files: src/iminuit/[^_].*\.py
 
 # C++ formatting
-- repo: https://github.com/ssciwr/clang-format-precommit
+- repo: https://github.com/ssciwr/clang-format-hook
   rev: v12.0.1
   hooks:
   - id: clang-format


### PR DESCRIPTION
The old name still works, of course, but we were asked to rename it to follow convention and so we did. Here’s the new name. Follow up to #688.