### PR TITLE
rename clang-format hook to official mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     files: src/iminuit/[^_].*\.py
 
 # C++ formatting
-- repo: https://github.com/ssciwr/clang-format-hook
+- repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v13.0.0
   hooks:
   - id: clang-format


### PR DESCRIPTION
I contributed types_or support to pre-commit's mirror tool, and now pre-commit mirrors clang-format directly, which removes the need for manual hook maintenance, so we are moving to using the official mirror. We are winding down the manual repository and suggesting users move to the official mirror. Same Python package, just a new hook location.

This should be the last rename here, I promise! :)