### PR TITLE
clean makefile, unpin 4.1.0 for sphinx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,17 @@
 # Makefile for developers with some convenient quick ways to do common things
 
-ifeq ($(shell python -c 'import sys; print(sys.version_info.major)'), 3)
-	PYTHON = python
-else
-	PYTHON = python3
-endif
-
 # default target
 build/done: $(wildcard *.py src/*.cpp extern/root/math/minuit2/src/*.cxx extern/root/math/minuit2/inc/*.h) CMakeLists.txt
-	DEBUG=1 $(PYTHON) setup.py develop
+	DEBUG=1 python3 setup.py develop
 	touch build/done
 
 test: build/done
-	$(PYTHON) -m pytest -vv -r a --ff --pdb
+	python3 -m pytest -vv -r a --ff --pdb
 
 cov: build/done
 	# This only computes the coverage in pure Python.
 	rm -rf htmlcov
-	$(PYTHON) -m pytest -x --ff --cov src/iminuit --cov-report term-missing --cov-report html
+	python3 -m pytest -x --ff --cov src/iminuit --cov-report term-missing --cov-report html
 
 doc: build/done build/html/done
 
@@ -29,7 +23,7 @@ build/html/done: doc/conf.py $(wildcard src/iminuit/*.py doc/*.rst doc/_static/*
 tutorial: build/done build/tutorial_done
 
 build/tutorial_done: $(wildcard src/iminuit/*.py doc/tutorial/*.ipynb)
-	$(PYTHON) -m pytest -n8 doc/tutorial
+	python3 -m pytest -n8 doc/tutorial
 	touch build/tutorial_done
 
 check:
@@ -42,5 +36,5 @@ clean:
 
 ## pylint is garbage, also see https://lukeplant.me.uk/blog/posts/pylint-false-positives/#running-total
 # pylint: build
-# 	@$(PYTHON) -m pylint -E src/$(PROJECT) -d E0611,E0103,E1126 -f colorized \
+# 	@python3 -m pylint -E src/$(PROJECT) -d E0611,E0103,E1126 -f colorized \
 # 	       --msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})'

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ test =
     nbsphinx
     boost_histogram
 doc =
-    sphinx==4.1
+    sphinx>=4.1
     sphinx-rtd-theme
     nbsphinx
     ipykernel


### PR DESCRIPTION
Two quick cleanups I noticed while working on recent PRs.

The Makefile can be made a bit cleaner now that python2 is no longer supported. I'd recommend looking into nox, as well; it can be much more reproducible, handing virtual environments for you. (I also hate make, so I'm biased).

I also ran into a problem with Sphnix - this pins 4.1.0 exactly, which doesn't support Python 3.10, so I couldn't build docs. You probably intended `==4.1.*`, but that's still not ideal; the 4.1 series is  not an LTS, so things like Python 3.10 support are not backported to it. I would either use `~=4.1`, which will allow 4.1 or newer, but not 5, or I'd use >=4.1, which is what I did here - [Pinning is generally a misused and terrible practice](https://iscinumpy.dev/post/bound-version-constraints). But up to you, docs is something you can pin. But I'd do at most `~=4.1`.
