### PR TITLE
include binaries for Python 3.10, musllinux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # version number must be string, otherwise 3.10 becomes 3.1
           - os: windows-latest
-            python-version: "3.10.0-rc.1"
+            python-version: "3.10"
           - os: macos-latest
             python-version: "3.6"
           - os: ubuntu-latest
-            python-version: pypy-3.6
+            python-version: "pypy-3.7"
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - run: python .ci/release_check.py
 
@@ -26,13 +26,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [auto, aarch64]
-        py: [cp36, cp37, cp38, cp39]
+        py: [cp36, cp37, cp38, cp39, cp310]
         include:
           - os: macos-latest
             py: cp38
             arch: universal2
           - os: macos-latest
             py: cp39
+            arch: universal2
+          - os: macos-latest
+            py: cp310
             arch: universal2
         exclude:
           - os: windows-latest
@@ -50,7 +53,7 @@ jobs:
       - if: ${{ matrix.arch == 'aarch64' }}
         uses: docker/setup-qemu-action@v1
 
-      - uses: pypa/cibuildwheel@v2.0.1
+      - uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: ${{ matrix.py }}-*
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -71,7 +74,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - run: python -m pip install --upgrade pip wheel
       - run: python setup.py sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,10 @@ before-build = "python -m pip install numpy --only-binary=:all:"
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 test-skip = ["*universal2:arm64"]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+
+[[tool.cibuildwheel.overrides]]
+select = "cp3?-*"
+manylinux-x86_64-image = "manylinux2010"
+manylinux-i686-image = "manylinux2010"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy


### PR DESCRIPTION
I've added 3.10 & musllinux (and probably PyPy 3.8 binaries too, forgot to check to see if PyPy binaries are included). Manylinux2010 is produced on 3.6-3.9, and 2014 for 3.10, just like NumPy. @HDembinski, is there a way to trigger the wheel build without an upload to make sure it works?

Also bumped the CI to include 3.10 final.
