### PR TITLE
fix: remove wheel from PEP 518 requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
     "cmake",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
"wheel" is included with proper version by `get_requires_for_build_wheel` from PEP 517, and isn't required for making an sdist, and might not be required in the future at all (in which case setuptools will modify `get_requires_for_build_wheel`). It's available even in setuptools 40.8.