### PR TITLE
fix ndof zero

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -474,7 +474,7 @@ class FMin:
         This returns NaN if the cost function is unbinned or does not support
         reporting the degrees of freedom.
         """
-        if np.isfinite(self._ndof):
+        if np.isfinite(self._ndof) and self._ndof > 0:
             return self.fval / self.errordef / self._ndof
         return np.nan
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -211,6 +211,14 @@ def test_BinnedNLL_bad_input_4():
         BinnedNLL([[1, 2, 3]], [1, 2], lambda x, a: 0)
 
 
+def test_BinnedNLL_ndof_zero():
+    c = BinnedNLL([1, 2], [0, 1, 2], lambda x, loc, scale: norm.cdf(x, loc, scale))
+    m = Minuit(c, loc=0, scale=1)
+    m.migrad()
+    assert c.ndata == m.nfit
+    assert np.isnan(m.fmin.reduced_chi2)
+
+
 @pytest.mark.parametrize("verbose", (0, 1))
 def test_ExtendedBinnedNLL(binned, verbose):
     mle, nx, xe = binned


### PR DESCRIPTION
iminuit raises an ZeroDivisionError when ndof is zero when printing the FMin object when the reduced chi2 is computed. This is not sensible, the sensible thing is to return nan in this case, so that's what this patch does.