### PR TITLE
Deprecate util.propagate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,6 @@ The iminuit package comes with additional features:
   - Non-linear regression with (optionally robust) weighted least-squares
   - Gaussian penalty terms
   - Cost functions can be combined by adding them: ``total_cost = cost_1 + cost_2``
-- Tools for numerical error propagation ``iminuit.util.propagate``
 - Support for SciPy minimisers as alternatives to Minuit's Migrad algorithm (optional)
 - Support for Numba accelerated functions (optional)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ black = 1
 minversion = "6.0"
 addopts = "-q -ra --ff"
 testpaths = ["tests"]
+filterwarnings = ["error"]
 
 [tool.cibuildwheel]
 # update skip when numpy wheels become available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ black = 1
 minversion = "6.0"
 addopts = "-q -ra --ff"
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore::ImportWarning",
+]
 
 [tool.cibuildwheel]
 # update skip when numpy wheels become available

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ test =
 doc =
     sphinx>=4.1
     sphinx-rtd-theme
+    Jinja2==3.0
     nbsphinx
 
 [check-manifest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,6 @@ test =
 doc =
     sphinx>=4.1
     sphinx-rtd-theme
-    Jinja2==3.0
     nbsphinx
 
 [check-manifest]

--- a/src/iminuit/_deprecated.py
+++ b/src/iminuit/_deprecated.py
@@ -1,4 +1,5 @@
 import warnings
+from numpy import VisibleDeprecationWarning
 
 
 class deprecated:
@@ -9,7 +10,7 @@ class deprecated:
         def decorated_func(*args, **kwargs):
             warnings.warn(
                 f"{func.__name__} is deprecated: {self._reason}",
-                category=DeprecationWarning,
+                category=VisibleDeprecationWarning,
                 stacklevel=2,
             )
             return func(*args, **kwargs)

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1,14 +1,12 @@
 """
 Data classes and utilities used by :class:`iminuit.Minuit`.
 
-You can look up the interface of data classes that iminuit uses here. Also of interest
-for users are :func:`propagate` and :func:`make_with_signature`.
+You can look up the interface of data classes that iminuit uses here.
 """
 import inspect
 from collections import OrderedDict
 from argparse import Namespace
-from . import _repr_html
-from . import _repr_text
+from . import _repr_html, _repr_text, _deprecated
 import numpy as np
 from typing import (
     Dict,
@@ -24,7 +22,6 @@ from typing import (
     TypeVar,
     Generic,
 )
-import types
 import abc
 from time import monotonic
 
@@ -982,16 +979,16 @@ def _jacobi(
     return y, jac
 
 
+@_deprecated.deprecated("use jacobi.propagate instead from jacobi library")
 def propagate(
     fn: Callable, x: Indexable[float], cov: Indexable[Indexable[float]]
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     Numerically propagates the covariance into a new space.
 
-    The function does error propagation. It computes C' = J C J^T, where C is the
-    covariance matrix of the input, C' the matrix of the output, and J is the Jacobi
-    matrix of first derivatives of the mapping function fn. The Jacobi matrix is
-    computed numerically.
+    This function is deprecated and will be removed. Please use jacobi.propagate from the
+    jacobi library, which is more accurate. The signatures of the two functions are
+    compatible, so it is a drop-in replacement.
 
     Parameters
     ----------
@@ -1079,12 +1076,7 @@ def make_with_signature(
         c = callable.__code__
         if c.co_argcount != len(vars):
             raise ValueError("number of parameters do not match")
-        if hasattr(c, "replace"):  # this was added after 3.6
-            # calling this introduces no overhead compared to original function
-            code = c.replace(co_varnames=vars)
-            return types.FunctionType(code, globals())
 
-    # fallback implementation with additional overhead
     class Caller:
         def __init__(self, varnames: Tuple[str, ...]):
             self.func_code = make_func_code(varnames)  # type:ignore

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,5 +1,6 @@
 from iminuit._deprecated import deprecated
 import pytest
+import numpy as np
 
 
 def test_deprecated_func():
@@ -7,5 +8,5 @@ def test_deprecated_func():
     def func(x):
         pass
 
-    with pytest.warns(DeprecationWarning, match="func is deprecated: bla"):
+    with pytest.warns(np.VisibleDeprecationWarning, match="func is deprecated: bla"):
         func(1)

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1,4 +1,3 @@
-import warnings
 import platform
 import pytest
 import numpy as np
@@ -25,19 +24,9 @@ is_pypy = platform.python_implementation() == "PyPy"
 
 
 def test_pedantic_warning_message():
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(IMinuitWarning, match=r"errordef not set, using 1"):
         m = Minuit(lambda x: 0, x=0)
         m.migrad()  # MARKER
-
-    with open(__file__) as f:
-        for lineno, line in enumerate(f):
-            if "m.migrad()  # MARKER" in line:
-                break
-
-    assert len(w) == 1
-    assert "errordef not set, using 1" in str(w[0].message)
-    assert w[0].filename == __file__
-    assert w[0].lineno == lineno + 1
 
 
 def test_version():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -447,11 +447,13 @@ def test_propagate_1():
     def fn(x):
         return 2 * x + 1
 
-    y, ycov = util.propagate(fn, x, cov)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_allclose(y, [3, 5, 7])
     np.testing.assert_allclose(ycov, [[4, 0.4, 0.8], [0.4, 8, 1.2], [0.8, 1.2, 12]])
 
-    y, ycov = util.propagate(fn, 1, 2)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, ycov = util.propagate(fn, 1, 2)
     np.testing.assert_allclose(y, 3)
     np.testing.assert_allclose(ycov, 8)
 
@@ -469,14 +471,16 @@ def test_propagate_2():
     def fn(x):
         return np.dot(a, x)
 
-    y, ycov = util.propagate(fn, x, cov)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_equal(y, fn(x))
     np.testing.assert_allclose(ycov, np.einsum("ij,kl,jl", a, a, cov))
 
     def fn(x):
         return np.linalg.multi_dot([x.T, cov, x])
 
-    y, ycov = util.propagate(fn, x, cov)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_equal(y, fn(np.array(x)))
     jac = 2 * np.dot(cov, x)
     np.testing.assert_allclose(ycov, np.einsum("i,k,ik", jac, jac, cov))
@@ -494,20 +498,22 @@ def test_propagate_3():
     def fn(x):
         return 2 * x + 1
 
-    y, ycov = util.propagate(fn, x, cov)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_allclose(y, [3, 5, 7])
     np.testing.assert_allclose(ycov, [[4, 0.0, 0.8], [0.0, 0.0, 0.0], [0.8, 0.0, 12]])
 
 
-def test_proagate_on_bad_input():
+def test_propagate_on_bad_input():
     cov = [[np.nan, 0.0], [0.0, 1.0]]
     x = [1.0, 2.0]
 
     def fn(x):
         return 2 * x + 1
 
-    with pytest.raises(ValueError):
-        util.propagate(fn, x, cov)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        with pytest.raises(ValueError):
+            util.propagate(fn, x, cov)
 
 
 def test_jacobi():


### PR DESCRIPTION
jacobi.propagate supersedes util.propagate, so util.propagate is deprecated.

Also fixes `make_with_signature` to always use the slow path. The fast path does not work on some functions. The exact conditions when it fails are not clear.

Use numpy.VisibleDeprecationWarning instead of warnings.DeprecationWarning and turn warnings during tests into failures.