### PR TITLE
Missing test files in SDist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include src/*.hpp
 include src/iminuit/*.py
 include tests/*.py
 include tests/*.txt
+include tests/*.html
 recursive-include extern/root/math/minuit2/inc *.h
 recursive-include extern/root/math/minuit2/src *.cxx
 recursive-include extern/pybind11/include *.h


### PR DESCRIPTION
Fixes conda-forge (and any other downstream packagers running tests)

I think only html files were added?

We should add the check-manifest check, as described in the Scikit-HEP developer guidelines.

