### PR TITLE
Minor updates (pybind11 segfault on pypy 3.9, flake8 broken mirror)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,6 @@ repos:
   - id: trailing-whitespace
     exclude: ^doc/_static/.*.svg
 
-# Python linter (Flake8)
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
-  hooks:
-  - id: flake8
-
 # Python formatting
 - repo: https://github.com/psf/black
   rev: 22.1.0
@@ -50,6 +44,12 @@ repos:
   hooks:
   - id: pydocstyle
     files: src/iminuit/[^_].*\.py
+
+# Python linter (Flake8)
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
 
 # C++ formatting
 - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ ignore =
 
 [flake8]
 max-line-length = 95
-ignore = E203,W503,E712
+extend-ignore = E203, E712
 
 [pydocstyle]
 convention = numpy


### PR DESCRIPTION
Main update is flake8, which was pointing at the old gitlab mirror, rather than the proper repo. Also moved the check (non-mutating checks should be after mutating ones like black).


- Update flake8 config (github, bump, move to after mutating checks)
- Minor pybind11 bump (fixes issues with the new PyPy 3.9)
