### PR TITLE
Removed unused and deprecated Black notebook config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.nbqa.mutate]
-black = 1
-
 [tool.mypy]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Editted: I mistook the usage of tool.nbqa.mutate black=1 to mean that the notebooks were supposed to be black formatted. Instead, I'm now just removing that old setting (which is deprecated, since black now natively supports jupyter notebook formatting).
