### PR TITLE
support custom grid in profile, mnprofile, contour; fix bug in draw_contour

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1703,8 +1703,11 @@ class Minuit:
         mncontour, mnprofile
         """
         if grid is not None:
-            xv = np.array(grid[0], dtype=float)
-            yv = np.array(grid[1], dtype=float)
+            xg, yg = grid
+            xv = np.array(xg, dtype=float)
+            yv = np.array(yg, dtype=float)
+            if xv.ndim != 1 or yv.ndim != 1:
+                raise ValueError("grid per parameter must be 1D array-like")
         else:
             if isinstance(bound, tuple):
                 xrange = self._normalize_bound(x, bound[0])

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -17,7 +17,9 @@ from ._core import (
 )
 import numpy as np
 import typing as _tp
-import numpy.typing as _ntp
+
+# import numpy.typing as _ntp
+_ArrayLike = _tp.Iterable  # use numpy.typing.ArrayLike in the future
 
 MnPrint.global_level = 0
 
@@ -1419,7 +1421,7 @@ class Minuit:
         *,
         size: int = 30,
         bound: _tp.Union[float, mutil.UserBound] = 2,
-        grid: _tp.Optional[_ntp.ArrayLike] = None,
+        grid: _tp.Optional[_ArrayLike] = None,
         subtract_min: bool = False,
     ) -> _tp.Tuple[np.ndarray, np.ndarray, np.ndarray]:
         r"""
@@ -1524,7 +1526,7 @@ class Minuit:
         *,
         size: int = 100,
         bound: _tp.Union[float, mutil.UserBound] = 2,
-        grid: _tp.Optional[_ntp.ArrayLike] = None,
+        grid: _tp.Optional[_ArrayLike] = None,
         subtract_min: bool = False,
     ) -> _tp.Tuple[np.ndarray, np.ndarray]:
         r"""
@@ -1653,7 +1655,7 @@ class Minuit:
         bound: _tp.Union[
             float, _tp.Tuple[_tp.Tuple[float, float], _tp.Tuple[float, float]]
         ] = 2,
-        grid: _tp.Optional[_tp.Tuple[_ntp.ArrayLike, _ntp.ArrayLike]] = None,
+        grid: _tp.Optional[_tp.Tuple[_ArrayLike, _ArrayLike]] = None,
         subtract_min: bool = False,
     ) -> _tp.Tuple[np.ndarray, np.ndarray, np.ndarray]:
         r"""

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -44,9 +44,12 @@ def test_profile_1(fig, minuit, arg):
 @pytest.mark.parametrize("arg", ("x", "y"))
 def test_profile_2(fig, minuit, arg):
     # plots with minos errors
-    minuit.minos()
     minuit.draw_profile(arg)
     plt.ylim(0, 5)
+
+
+def test_profile_3(fig, minuit):
+    minuit.draw_profile("x", grid=np.linspace(0, 5))
 
 
 @pytest.mark.parametrize("arg", ("x", "y"))
@@ -62,6 +65,11 @@ def test_mnprofile_2(fig, minuit, arg):
     minuit.minos()
     minuit.draw_mnprofile(arg)
     plt.ylim(0, 5)
+
+
+def test_mnprofile_3(fig, minuit):
+    minuit.minos()
+    minuit.draw_mnprofile("x", grid=np.linspace(0, 5))
 
 
 def test_mncontour_1(fig, minuit):
@@ -86,3 +94,11 @@ def test_contour_2(fig, minuit):
 
 def test_contour_3(fig, minuit):
     minuit.draw_contour("x", "y", size=100, bound=((-0.5, 2.5), (-1, 3)))
+
+
+def test_contour_4(fig, minuit):
+    minuit.draw_contour("x", "y", size=(10, 50), bound=((-0.5, 2.5), (-1, 3)))
+
+
+def test_contour_5(fig, minuit):
+    minuit.draw_contour("x", "y", grid=(np.linspace(-0.5, 2.5), np.linspace(-1, 3)))

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -611,6 +611,26 @@ def test_contour(grad):
     assert_allclose(func0(X, Y), v.T)
 
 
+def test_contour_separate_size():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    x, y, v = m.contour("x", "y", size=(10, 20))
+    assert len(x) == 10
+    assert len(y) == 20
+    X, Y = np.meshgrid(x, y)
+    assert_allclose(func0(X, Y), v.T)
+
+
+def test_contour_grid():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    x, y, v = m.contour("x", "y", grid=(np.linspace(0, 2, 10), np.linspace(0, 4, 20)))
+    assert len(x) == 10
+    assert len(y) == 20
+    X, Y = np.meshgrid(x, y)
+    assert_allclose(func0(X, Y), v.T)
+
+
 @pytest.mark.parametrize("grad", (None, func0_grad))
 def test_profile(grad):
     m = Minuit(func0, grad=grad, x=1.0, y=2.0)
@@ -622,6 +642,16 @@ def test_profile(grad):
     v2 = m.profile("y", subtract_min=True)[1]
     assert np.min(v2) == 0
     assert_allclose(v - np.min(v), v2)
+
+
+def test_profile_grid():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    y, v = m.profile("y", grid=np.linspace(0, 4, 15))
+    assert len(y) == 15
+    assert y[0] == 0
+    assert y[-1] == 4
+    assert_allclose(func0(m.values[0], y), v)
 
 
 @pytest.mark.parametrize("grad", (None, func0_grad))
@@ -646,6 +676,23 @@ def test_mnprofile(grad):
     y, v3, _ = m.mnprofile("y", size=10, subtract_min=True)
     assert np.min(v3) == 0
     assert_allclose(v - np.min(v), v3)
+
+
+def test_mnprofile_grid():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    y, v, _ = m.mnprofile("y", grid=np.linspace(0, 4, 15))
+    assert len(y) == 15
+    assert y[0] == 0
+    assert y[-1] == 4
+    m2 = Minuit(func0, x=1.0, y=2.0)
+    m2.fixed[1] = True
+    v2 = []
+    for yi in y:
+        m2.values = (m.values[0], yi)
+        m2.migrad()
+        v2.append(m2.fval)
+    assert_allclose(v, v2)
 
 
 def test_contour_subtract():

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -631,6 +631,22 @@ def test_contour_grid():
     assert_allclose(func0(X, Y), v.T)
 
 
+def test_contour_bad_grid():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    with pytest.raises(ValueError):
+        m.contour("x", "y", grid=([1, 2, 3], [[1, 2, 3]]))
+
+    with pytest.raises(ValueError):
+        m.contour("x", "y", grid=([1, 2, 3],))
+
+    with pytest.raises(ValueError):
+        m.contour("x", "y", grid=([1, 2, 3], [1, 2], [3, 4]))
+
+    with pytest.raises(ValueError):
+        m.contour("x", "y", grid=(10, [1, 2, 3]))
+
+
 @pytest.mark.parametrize("grad", (None, func0_grad))
 def test_profile(grad):
     m = Minuit(func0, grad=grad, x=1.0, y=2.0)
@@ -652,6 +668,16 @@ def test_profile_grid():
     assert y[0] == 0
     assert y[-1] == 4
     assert_allclose(func0(m.values[0], y), v)
+
+
+def test_profile_bad_grid():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    with pytest.raises(ValueError):
+        m.profile("y", grid=[[1, 2, 3]])
+
+    with pytest.raises(ValueError):
+        m.profile("y", grid=10)
 
 
 @pytest.mark.parametrize("grad", (None, func0_grad))
@@ -693,6 +719,15 @@ def test_mnprofile_grid():
         m2.migrad()
         v2.append(m2.fval)
     assert_allclose(v, v2)
+
+
+def test_mnprofile_bad_grid():
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    with pytest.raises(ValueError):
+        m.mnprofile("y", grid=10)
+    with pytest.raises(ValueError):
+        m.mnprofile("y", grid=[[10, 20]])
 
 
 def test_contour_subtract():


### PR DESCRIPTION
Closes #745 

This adds the `grid` keyword for Minuit.profile, Minuit.mnprofile, Minuit.contour. It allows users to select the points where the profile or mnprofile or contour should be evaluated.

Minuit.contour now also accepts two sizes for its `size` keyword, which are then used for each parameter, respectively.

A bug in Minuit.contour was fixed. The contour was plotted rotated by 90 degrees before.