### PR TITLE
workaround for FMin.is_valid

### DIFF
--- a/src/functionminimum.cpp
+++ b/src/functionminimum.cpp
@@ -34,23 +34,17 @@ void bind_functionminimum(py::module m) {
       .def_property_readonly("state", &FunctionMinimum::UserState)
       .def_property_readonly("edm", &FunctionMinimum::Edm)
       .def_property_readonly("fval", &FunctionMinimum::Fval)
-      // TODO this needs to be fixed upstream in ROOT
-      .def_property_readonly("is_valid",
-                             [](const FunctionMinimum& self) {
-                               return self.IsValid() && !std::isnan(self.Edm());
-                             })
-      // FunctionMinimum::HasValidParameters is not wrapped to Python
+      .def_property_readonly("is_valid", &FunctionMinimum::IsValid)
+      // No need to wrap HasValidParameters
+      // .def_property_readonly("has_valid_parameters",
+      //                        &FunctionMinimum::HasValidParameters)
       .def_property_readonly("has_accurate_covar", &FunctionMinimum::HasAccurateCovar)
       .def_property_readonly("has_posdef_covar", &FunctionMinimum::HasPosDefCovar)
       .def_property_readonly("has_made_posdef_covar",
                              &FunctionMinimum::HasMadePosDefCovar)
       .def_property_readonly("hesse_failed", &FunctionMinimum::HesseFailed)
       .def_property_readonly("has_covariance", &FunctionMinimum::HasCovariance)
-      // TODO this needs to be fixed upstream in ROOT
-      .def_property_readonly("is_above_max_edm",
-                             [](const FunctionMinimum& self) {
-                               return self.IsAboveMaxEdm() || std::isnan(self.Edm());
-                             })
+      .def_property_readonly("is_above_max_edm", &FunctionMinimum::IsAboveMaxEdm)
       .def_property_readonly("has_reached_call_limit",
                              &FunctionMinimum::HasReachedCallLimit)
       .def_property("errordef", &FunctionMinimum::Up, &FunctionMinimum::SetErrorDef)

--- a/src/functionminimum.cpp
+++ b/src/functionminimum.cpp
@@ -34,16 +34,23 @@ void bind_functionminimum(py::module m) {
       .def_property_readonly("state", &FunctionMinimum::UserState)
       .def_property_readonly("edm", &FunctionMinimum::Edm)
       .def_property_readonly("fval", &FunctionMinimum::Fval)
-      .def_property_readonly("is_valid", &FunctionMinimum::IsValid)
-      .def_property_readonly("has_valid_parameters",
-                             &FunctionMinimum::HasValidParameters)
+      // TODO this needs to be fixed upstream in ROOT
+      .def_property_readonly("is_valid",
+                             [](const FunctionMinimum& self) {
+                               return self.IsValid() && !std::isnan(self.Edm());
+                             })
+      // FunctionMinimum::HasValidParameters is not wrapped to Python
       .def_property_readonly("has_accurate_covar", &FunctionMinimum::HasAccurateCovar)
       .def_property_readonly("has_posdef_covar", &FunctionMinimum::HasPosDefCovar)
       .def_property_readonly("has_made_posdef_covar",
                              &FunctionMinimum::HasMadePosDefCovar)
       .def_property_readonly("hesse_failed", &FunctionMinimum::HesseFailed)
       .def_property_readonly("has_covariance", &FunctionMinimum::HasCovariance)
-      .def_property_readonly("is_above_max_edm", &FunctionMinimum::IsAboveMaxEdm)
+      // TODO this needs to be fixed upstream in ROOT
+      .def_property_readonly("is_above_max_edm",
+                             [](const FunctionMinimum& self) {
+                               return self.IsAboveMaxEdm() || std::isnan(self.Edm());
+                             })
       .def_property_readonly("has_reached_call_limit",
                              &FunctionMinimum::HasReachedCallLimit)
       .def_property("errordef", &FunctionMinimum::Up, &FunctionMinimum::SetErrorDef)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -228,7 +228,6 @@ def test_FunctionMinimum_pickle():
     assert fm.edm == fm2.edm
     assert fm.fval == fm2.fval
     assert fm.is_valid == fm2.is_valid
-    assert fm.has_valid_parameters == fm2.has_valid_parameters
     assert fm.has_accurate_covar == fm2.has_accurate_covar
     assert fm.has_posdef_covar == fm2.has_posdef_covar
     assert fm.has_made_posdef_covar == fm2.has_made_posdef_covar

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -120,7 +120,10 @@ def test_issue_687():
 
 def test_issue_694():
     from iminuit.cost import ExtendedUnbinnedNLL
-    from scipy.stats import norm, expon
+
+    stats = pytest.importorskip("scipy.stats")
+    norm = stats.norm
+    expon = stats.expon
 
     xmus = 1.0
     xmub = 5.0


### PR DESCRIPTION
Closes #694

This is fixes a bug in upstream Minuit2. When the EDM value is NaN, Minuit2 wrongly reports that the EDM value is below the threshold and claims that the minimum is valid. This patch fixes the issue in the class FunctionMinimum, which is good, but a deeper issue remains: MnMigrad does not handle NaNs correctly.

This also updates ROOT to master + my outstanding ROOT patches.