### PR TITLE
External pybind11 option (such as in conda-forge)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON) # optional, ensure standard is supported
 set(CMAKE_CXX_EXTENSIONS OFF) # optional, keep compiler extensionsn off
 
 # Now we can find pybind11
-add_subdirectory(extern/pybind11)
+option(IMINUIT_EXTERNAL_PYBIND11 "Build against an external pybind11" OFF)
+if(IMINUIT_EXTERNAL_PYBIND11)
+  find_package(pybind11 CONFIG REQUIRED)
+else()
+  add_subdirectory(extern/pybind11)
+endif()
 
 file(GLOB SOURCES_A "src/*.cpp")
 set(SOURCES_B


### PR DESCRIPTION
This enables packagers (conda-forge, in this case) to use their own packaged version of pybind11. For conda-forge, this will enable iminuit to particle in ABI binning migrations that we've recently developed (pybind11's ABI hasn't changed in two years, but an ABI bump is coming). It also enables quicker response if there's an issue such as in https://github.com/conda-forge/iminuit-feedstock/pull/76.

This is _optional_ and orthogonal to #742 (which is also needed - iminuit segfaults on PyPy 3.9 without it). If you do not expect anyone to use the binary ABI of iMinuit _and_ you want to fully control the exact pybind11 version, then you don't need to go for this option. I think iMinuit would have use for the binary ABI. Boost-histogram does not. Awkward might (it originally would have, not sure about v2).
