### PR TITLE
make errordef=1 the default

### DIFF
--- a/src/fcn.cpp
+++ b/src/fcn.cpp
@@ -47,16 +47,7 @@ std::vector<double> FCN::Gradient(const std::vector<double>& x) const {
   return check_vector(py::cast<std::vector<double>>(grad_(*py::cast(x))), x);
 }
 
-double FCN::Up() const {
-  if (errordef_ == 0) {
-    auto m = py::module_::import("warnings");
-    auto util = py::module_::import("iminuit.util");
-    m.attr("warn")("errordef not set, using 1 (appropriate for least-squares)",
-                   util.attr("IMinuitWarning"), 2);
-    errordef_ = 1.0;
-  }
-  return errordef_;
-}
+double FCN::Up() const { return errordef_; }
 
 void set_errordef(FCN& self, double value) {
   if (value > 0) {

--- a/src/iminuit/__init__.py
+++ b/src/iminuit/__init__.py
@@ -7,8 +7,6 @@ Basic usage example::
     def fcn(x, y, z):
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
-    fcn.errordef = Minuit.LEAST_SQUARES
-
     m = Minuit(fcn, x=0, y=0, z=0)
     m.migrad()
     m.hesse()

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -605,7 +605,7 @@ class Minuit:
             fcn,
             getattr(fcn, "grad", grad),
             array_call,
-            getattr(fcn, "errordef", 0.0),
+            getattr(fcn, "errordef", 1.0),
         )
 
         self._init_state = _make_init_state(self._pos2var, start, kwds)

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -497,7 +497,17 @@ class Minuit:
 
         Notes
         -----
-        *Accepted callables*
+        *Callables*
+
+        By default, Minuit assumes that the callable `fcn` behaves like chi-square
+        function, meaning that the function minimum in repeated identical random
+        experiments is chi-square distributed up to an arbitrary additive constant. This
+        is important for the correct error calculation. If `fcn` returns a log-likelihood,
+        one should multiply the result with -2 to adapt it. If the function returns the
+        negated log-likelihood, one can alternatively set the attribute
+        `fcn.errordef` = :attr:`Minuit.LIKELIHOOD` or
+        :attr:`Minuit.errordef` = :attr:`Minuit.LIKELIHOOD` after initialization to make
+        Minuit calculate errors properly.
 
         Minuit reads the function signature of `fcn` to detect the number and names of the
         function parameters. Two kinds of function signatures are understood.
@@ -526,11 +536,11 @@ class Minuit:
             an array-like type, e.g. a numpy array, tuple or list. For more details,
             see "Parameter Keyword Arguments" further down.
 
-        In some cases, the detection fails, for example for a function like this::
+        In some cases, the detection fails, for example, for a function like this::
 
                 def difficult_fcn(*args): ...
 
-        To use such a function, set `name`.
+        To use such a function, set the `name` keyword as described further below.
 
         *Parameter initialization*
 

--- a/src/iminuit/testing.py
+++ b/src/iminuit/testing.py
@@ -14,9 +14,6 @@ def rosenbrock(x, y):
     return (1 - x) ** 2 + 100 * (y - x**2) ** 2
 
 
-rosenbrock.errordef = 1
-
-
 def rosenbrock_grad(x, y):
     """Gradient of Rosenbrock function."""
     return (-400 * x * (-(x**2) + y) + 2 * x - 2, -200 * x**2 + 200 * y)
@@ -35,9 +32,6 @@ def ackley(x, y):
     return term1 + term2 + 20 + e
 
 
-ackley.errordef = 1
-
-
 def beale(x, y):
     """
     Beale function. Minimum: f(3, 0.5) = 0.
@@ -50,9 +44,6 @@ def beale(x, y):
     return term1 * term1 + term2 * term2 + term3 * term3
 
 
-beale.errordef = 1
-
-
 def matyas(x, y):
     """
     Matyas function. Minimum: f(0, 0) = 0.
@@ -60,9 +51,6 @@ def matyas(x, y):
     https://en.wikipedia.org/wiki/Test_functions_for_optimization
     """
     return 0.26 * (x**2 + y**2) - 0.48 * x * y
-
-
-matyas.errordef = 1
 
 
 def sphere_np(x):
@@ -74,6 +62,3 @@ def sphere_np(x):
     import numpy as np
 
     return np.sum(x**2)
-
-
-sphere_np.errordef = 1

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -13,9 +13,6 @@ def f1(x, y):
     return (1 - x) ** 2 + np.exp((y - 1) ** 2)
 
 
-f1.errordef = 1
-
-
 @pytest.fixture
 def minuit():
     m = Minuit(f1, x=0, y=0)

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -5,13 +5,7 @@ import pytest
 import numpy as np
 
 
-def lsq(func):
-    func.errordef = Minuit.LEAST_SQUARES
-    return func
-
-
 def test_issue_424():
-    @lsq
     def fcn(x, y, z):
         return (x - 1) ** 2 + (y - 4) ** 2 / 2 + (z - 9) ** 2 / 3
 
@@ -26,7 +20,6 @@ def test_issue_424():
 
 
 def test_issue_544():
-    @lsq
     def fcn(x, y):
         return x**2 + y**2
 
@@ -38,7 +31,6 @@ def test_issue_544():
 
 def test_issue_648():
     class F:
-        errordef = 1
         first = True
 
         def __call__(self, a, b):
@@ -53,7 +45,6 @@ def test_issue_648():
 
 
 def test_issue_643():
-    @lsq
     def fcn(x, y, z):
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
@@ -73,7 +64,6 @@ def test_issue_643():
 
 
 def test_issue_669():
-    @lsq
     def fcn(x, y):
         return x**2 + (y / 2) ** 2
 
@@ -94,7 +84,6 @@ def test_issue_669():
         assert match
 
 
-@lsq
 def fcn(par):
     return np.sum(par**2)
 

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -59,24 +59,12 @@ def block_scipy_optimize():
 is_pypy = platform.python_implementation() == "PyPy"
 
 
-def test_pedantic_warning_message():
-    with pytest.warns(IMinuitWarning, match=r"errordef not set, using 1"):
-        m = Minuit(lambda x: 0, x=0)
-        m.migrad()  # MARKER
-
-
 def test_version():
     import iminuit
 
     assert iminuit.__version__
 
 
-def lsq(func):
-    func.errordef = Minuit.LEAST_SQUARES
-    return func
-
-
-@lsq
 def func0(x, y):  # values = (2.0, 5.0), errors = (2.0, 1.0)
     return (x - 2.0) ** 2 / 4.0 + np.exp((y - 5.0) ** 2) + 10
 
@@ -104,7 +92,6 @@ class Func2:
         return func0(arg[0], arg[1]) * 4
 
 
-@lsq
 def func4(x, y, z):
     return 0.2 * (x - 2.0) ** 2 + 0.1 * (y - 5.0) ** 2 + 0.25 * (z - 7.0) ** 2 + 10
 
@@ -116,7 +103,6 @@ def func4_grad(x, y, z):
     return dfdx, dfdy, dfdz
 
 
-@lsq
 def func5(x, long_variable_name_really_long_why_does_it_has_to_be_this_long, z):
     return (
         (x - 1) ** 2
@@ -132,7 +118,6 @@ def func5_grad(x, long_variable_name_really_long_why_does_it_has_to_be_this_long
     return dfdx, dfdy, dfdz
 
 
-@lsq
 def func6(x, m, s, a):
     return a / ((x - m) ** 2 + s**2)
 
@@ -151,7 +136,6 @@ class Correlated:
         return np.dot(x.T, np.dot(self.cinv, x))
 
 
-@lsq
 def func_np(x):  # test numpy support
     return np.sum((x - 1) ** 2)
 
@@ -1382,7 +1366,6 @@ def test_migrad_iterate():
 
 
 def test_precision():
-    @lsq
     def fcn(x):
         return np.exp(x * x + 1)
 
@@ -1504,7 +1487,6 @@ def test_cfunc():
 
     c_sig = nb.types.double(nb.types.uintc, nb.types.CPointer(nb.types.double))
 
-    @lsq
     @nb.cfunc(c_sig)
     def fcn(n, x):
         x = nb.carray(x, (n,))
@@ -1608,7 +1590,7 @@ def test_pickle(grad):
 
 def test_minos_new_min():
     xref = [1.0]
-    m = Minuit(lsq(lambda x: (x - xref[0]) ** 2), x=0)
+    m = Minuit(lambda x: (x - xref[0]) ** 2, x=0)
     m.migrad()
     assert m.values[0] == approx(xref[0], abs=1e-3)
     m.minos()
@@ -1624,7 +1606,7 @@ def test_minos_new_min():
 
 
 def test_minos_without_migrad():
-    m = Minuit(lsq(lambda x, y: (x - 1) ** 2 + (y / 2) ** 2), 1.001, 0.001)
+    m = Minuit(lambda x, y: (x - 1) ** 2 + (y / 2) ** 2, 1.001, 0.001)
     m.minos()
     me = m.merrors["x"]
     assert me.is_valid

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -123,8 +123,6 @@ def func6(x, m, s, a):
 
 
 class Correlated:
-    errordef = 1
-
     def __init__(self):
         sx = 2
         sy = 1
@@ -228,7 +226,7 @@ def test_func0():  # check that providing gradient improves convergence
 
 
 def test_lambda():
-    func_test_helper(lambda x, y: func0(x, y), errordef=1)
+    func_test_helper(lambda x, y: func0(x, y))
 
 
 def test_Func1():
@@ -243,8 +241,6 @@ def test_no_signature():
     def no_signature(*args):
         x, y = args
         return (x - 1) ** 2 + (y - 2) ** 2
-
-    no_signature.errordef = 1
 
     m = Minuit(no_signature, 3, 4)
     assert m.values == (3, 4)
@@ -352,7 +348,6 @@ def test_array_func_2():
 
 def test_wrong_use_of_array_init():
     m = Minuit(lambda a, b: a**2 + b**2, (1, 2))
-    m.errordef = Minuit.LEAST_SQUARES
     with pytest.raises(TypeError):
         m.migrad()
 
@@ -583,7 +578,6 @@ def test_minos_single_nonsense_variable():
 
 def test_minos_with_bad_fmin():
     m = Minuit(lambda x: 0, x=0)
-    m.errordef = 1
     m.migrad()
     with pytest.raises(RuntimeError):
         m.minos()
@@ -598,7 +592,6 @@ def test_fixing_long_variable_name(grad):
         x=0,
         z=0,
     )
-    m.errordef = 1
     m.fixed["long_variable_name_really_long_why_does_it_has_to_be_this_long"] = True
     m.migrad()
     assert_allclose(m.values, [1, 2, -1], atol=1e-3)
@@ -816,7 +809,6 @@ def test_mncontour_no_fmin():
 
 def test_mncontour_with_fixed_var():
     m = Minuit(func0, x=0, y=0)
-    m.errordef = 1
     m.fixed["x"] = True
     m.migrad()
     with pytest.raises(ValueError):
@@ -858,7 +850,6 @@ def test_mnprofile_array_func():
 
 def test_mnprofile_bad_func():
     m = Minuit(lambda x, y: 0, 0, 0)
-    m.errordef = 1
     with pytest.warns(IMinuitWarning):
         m.mnprofile("x")
 
@@ -932,7 +923,6 @@ def test_values(minuit):
 def test_fmin():
     m = Minuit(lambda x, s: (x * s) ** 2, x=1, s=1)
     m.fixed["s"] = True
-    m.errordef = 1
     m.migrad()
     fm1 = m.fmin
     assert fm1.is_valid
@@ -951,7 +941,6 @@ def test_chi2_fit():
         return (x - 1) ** 2 + ((y - 2) / 3) ** 2
 
     m = Minuit(chi2, x=0, y=0)
-    m.errordef = 1
     m.migrad()
     assert_allclose(m.values, (1, 2))
     assert_allclose(m.errors, (1, 3))
@@ -1028,7 +1017,6 @@ def test_oneside_outside():
 def test_migrad_ncall():
     class Func:
         nfcn = 0
-        errordef = 1
 
         def __call__(self, x):
             self.nfcn += 1
@@ -1057,7 +1045,6 @@ def test_migrad_ncall():
 
 def test_ngrad():
     class Func:
-        errordef = 1
         ngrad = 0
 
         def __call__(self, x):
@@ -1112,7 +1099,6 @@ def test_print_level():
 
 def test_params():
     m = Minuit(func0, x=1, y=2)
-    m.errordef = Minuit.LEAST_SQUARES
     m.errors = (3, 4)
     m.fixed["x"] = True
     m.limits["y"] = (None, 10)
@@ -1145,7 +1131,6 @@ def test_params():
 
 def test_non_analytical_function():
     class Func:
-        errordef = 1
         i = 0
 
         def __call__(self, a):
@@ -1160,7 +1145,6 @@ def test_non_analytical_function():
 
 def test_non_invertible():
     m = Minuit(lambda x, y: 0, 1, 2)
-    m.errordef = 1
     m.strategy = 0
     m.migrad()
     assert m.fmin.is_valid
@@ -1171,7 +1155,6 @@ def test_non_invertible():
 
 def test_function_without_local_minimum():
     m = Minuit(lambda a: -a, 0)
-    m.errordef = 1
     m.migrad()
     assert m.fmin.is_valid is False
     assert m.fmin.is_above_max_edm is True
@@ -1182,7 +1165,6 @@ def test_function_with_maximum():
         return -(a**2)
 
     m = Minuit(func, a=0)
-    m.errordef = 1
     m.migrad()
     assert m.fmin.is_valid is False
 
@@ -1192,7 +1174,6 @@ def test_perfect_correlation():
         return (a - b) ** 2
 
     m = Minuit(func, a=1, b=2)
-    m.errordef = 1
     m.migrad()
     assert m.fmin.is_valid is True
     assert m.fmin.has_accurate_covar is False
@@ -1241,7 +1222,6 @@ def test_hesse_without_migrad():
     assert m.fmin
 
     m = Minuit(lambda x: 0, 0)
-    m.errordef = 1
     m.hesse()
     assert not m.accurate
     assert m.fmin.hesse_failed
@@ -1282,7 +1262,6 @@ def returning_garbage(x):
 )
 def test_bad_functions(func, expected):
     m = Minuit(func, x=1)
-    m.errordef = 1
     m.throw_nan = True
     with pytest.raises(type(expected)) as excinfo:
         m.migrad()
@@ -1291,7 +1270,6 @@ def test_bad_functions(func, expected):
 
 def test_throw_nan():
     m = Minuit(returning_nan, x=1)
-    m.errordef = 1
     assert not m.throw_nan
     m.migrad()
     m.throw_nan = True
@@ -1324,7 +1302,6 @@ def returning_noniterable(x):
 )
 def test_bad_functions_np(func, expected):
     m = Minuit(lambda x: np.dot(x, x), (1, 1), grad=func)
-    m.errordef = 1
     m.throw_nan = True
     with pytest.raises(type(expected)) as excinfo:
         m.migrad()
@@ -1334,14 +1311,12 @@ def test_bad_functions_np(func, expected):
 @pytest.mark.parametrize("sign", (-1, 1))
 def test_parameter_at_limit(sign):
     m = Minuit(lambda x: (x - sign * 1.2) ** 2, x=0)
-    m.errordef = 1
     m.limits["x"] = (-1, 1)
     m.migrad()
     assert m.values["x"] == approx(sign * 1.0, abs=1e-3)
     assert m.fmin.has_parameters_at_limit is True
 
     m = Minuit(lambda x: (x - sign * 1.2) ** 2, x=0)
-    m.errordef = 1
     m.migrad()
     assert m.values["x"] == approx(sign * 1.2, abs=1e-3)
     assert m.fmin.has_parameters_at_limit is False
@@ -1353,14 +1328,12 @@ def test_inaccurate_fcn(iterate, valid):
         return abs(x) ** 10 + 1e7
 
     m = Minuit(f, x=2)
-    m.errordef = 1
     m.migrad(iterate=iterate)
     assert m.valid == valid
 
 
 def test_migrad_iterate():
     m = Minuit(lambda x: 0, x=2)
-    m.errordef = 1
     with pytest.raises(ValueError):
         m.migrad(iterate=0)
 
@@ -1619,18 +1592,12 @@ def test_minos_without_migrad():
 
 
 def test_missing_ndata():
-    def fcn(a):
-        return a
-
-    fcn.errordef = 1
-
-    m = Minuit(fcn, 1)
+    m = Minuit(lambda a: a, 1)
     assert_equal(m.ndof, np.nan)
 
 
 def test_call_limit_reached_in_hesse():
     m = Minuit(lambda x: ((x - 1.2) ** 4).sum(), np.ones(10) * 10)
-    m.errordef = 1
     m.migrad(ncall=200)
     assert m.fmin.has_reached_call_limit
     assert m.fmin.nfcn < 205

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -15,9 +15,6 @@ def f1(x, y):
     return (x - 2) ** 2 + (y - 1) ** 2 / 0.25 + 1
 
 
-f1.errordef = 1
-
-
 def test_color_1():
     g = _repr_html.ColorGradient((-1, 10, 10, 20), (2, 20, 20, 10))
     assert g.rgb(-1) == "rgb(10,10,20)"
@@ -219,7 +216,6 @@ def test_html_correlation_matrix():
 
 def test_html_minuit():
     m = Minuit(lambda x, y: x**2 + 4 * y**2, x=0, y=0)
-    m.errordef = 1
     assert m._repr_html_() == m.params._repr_html_()
     m.migrad()
     assert (
@@ -351,7 +347,6 @@ def test_text_matrix_difficult_values():
 
 def test_text_minuit():
     m = Minuit(lambda x, y: x**2 + 4 * y**2, x=0, y=0)
-    m.errordef = 1
     assert str(m) == str(m.params)
     m.migrad()
     assert str(m) == str(m.fmin) + "\n" + str(m.params) + "\n" + str(m.covariance)

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -11,9 +11,6 @@ def fcn(a, b):
     return a**2 + ((b - 1) / 2.0) ** 2 + 3
 
 
-fcn.errordef = 1
-
-
 def grad(a, b):
     return 2 * a, b - 1
 
@@ -49,7 +46,6 @@ def hessp(a, b, v):
 )
 def test_scipy_method(array_call, fixed, method):
     fn = (lambda par: fcn(*par)) if array_call else fcn
-    fn.errordef = 1
 
     gr = None
     he = None
@@ -197,7 +193,6 @@ def test_scipy_constraints_1(lb, fixed):
 
     m = Minuit(fcn, a=3, x=1, y=2)
     m.fixed["a"] = fixed
-    m.errordef = 1
     con_a = scopt.NonlinearConstraint(lambda a, x, y: a, lb, np.inf)
     con_x = scopt.NonlinearConstraint(lambda a, x, y: x, lb, np.inf)
     con_y = scopt.NonlinearConstraint(lambda a, x, y: y, lb, np.inf)
@@ -216,7 +211,6 @@ def test_scipy_constraints_2(fixed):
         return x**2 + y**2
 
     m = Minuit(fcn, x=1, y=2)
-    m.errordef = 1
     m.fixed["x"] = fixed
     con = scopt.LinearConstraint([1, 1], 0.1, np.inf)
     m.scipy(method="COBYLA", constraints=con)

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -10,7 +10,6 @@ def framed(s):
 
 def test_params():
     m = Minuit(lambda x, y: x**2 + (y / 2) ** 2 + 1, x=0, y=0)
-    m.errordef = 1
     m.limits["y"] = (-1, 1)
     m.fixed["x"] = True
     m.migrad()
@@ -28,7 +27,6 @@ def test_params():
 
 def test_matrix():
     m = Minuit(lambda x, y: x**2 + (y / 2) ** 2 + 1, x=0, y=0)
-    m.errordef = 1
     m.migrad()
     assert (
         framed(tab.tabulate(*m.covariance.to_table()))


### PR DESCRIPTION
This removes the warning when a cost function does not provide an attribute called `errordef`. Instead, all functions without `errordef` are treated as if they are chi2-like.