### PR TITLE
fix bug in error heuristic and prevent assigning non-positive values

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -237,10 +237,10 @@ class Minuit:
     def values(self) -> mutil.ValueView:
         """Access parameter values via an array-like view.
 
-        Use to read or write current parameter values based on the parameter index or the
-        parameter name as a string. If you change a parameter value and run :meth:`migrad`,
-        the minimization will start from that value, similar for :meth:`hesse` and
-        :meth:`minos`.
+        Use to read or write current parameter values based on the parameter index
+        or the parameter name as a string. If you change a parameter value and run
+        :meth:`migrad`, the minimization will start from that value, similar for
+        :meth:`hesse` and :meth:`minos`.
 
         See Also
         --------
@@ -256,8 +256,9 @@ class Minuit:
     def errors(self) -> mutil.ErrorView:
         """Access parameter parabolic errors via an array-like view.
 
-        Like :attr:`values`, but instead of reading or writing the values, you read or write
-        the errors (which double as step sizes for MINUITs numerical gradient estimation).
+        Like :attr:`values`, but instead of reading or writing the values, you read
+        or write the errors (which double as step sizes for MINUITs numerical gradient
+        estimation). Only positive values are accepted when assigning to errors.
 
         See Also
         --------
@@ -273,13 +274,13 @@ class Minuit:
     def fixed(self) -> mutil.FixedView:
         """Access whether parameters are fixed via an array-like view.
 
-        Use to read or write the fixation state of a parameter based on the parameter index
-        or the parameter name as a string. If you change the state and run :meth:`migrad`,
-        :meth:`hesse`, or :meth:`minos`, the new state is used.
+        Use to read or write the fixation state of a parameter based on the parameter
+        index or the parameter name as a string. If you change the state and run
+        :meth:`migrad`, :meth:`hesse`, or :meth:`minos`, the new state is used.
 
-        In case of complex fits, it can help to fix some parameters first and only minimize
-        the function with respect to the other parameters, then release the fixed parameters
-        and minimize again starting from that state.
+        In case of complex fits, it can help to fix some parameters first and only
+        minimize the function with respect to the other parameters, then release the
+        fixed parameters and minimize again starting from that state.
 
         See Also
         --------
@@ -296,8 +297,8 @@ class Minuit:
         """Access parameter limits via a array-like view.
 
         Use to read or write the limits of a parameter based on the parameter index
-        or the parameter name as a string. If you change the limits and run :meth:`migrad`,
-        :meth:`hesse`, or :meth:`minos`, the new state is used.
+        or the parameter name as a string. If you change the limits and run
+        :meth:`migrad`, :meth:`hesse`, or :meth:`minos`, the new state is used.
 
         In case of complex fits, it can help to limit some parameters first, run Migrad,
         then remove the limits and run Migrad again. Limits will bias the result only if

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -12,6 +12,7 @@ import numpy as np
 import typing as _tp
 import abc
 from time import monotonic
+import warnings
 
 
 class IMinuitWarning(RuntimeWarning):
@@ -138,6 +139,12 @@ class ErrorView(BasicView):
         return self._minuit._last_state[i].error  # type:ignore
 
     def _set(self, i: int, value: float) -> None:
+        if value <= 0:
+            warnings.warn(
+                "Assigned errors must be positive. "
+                "Non-positive values are replaced by a heuristic."
+            )
+            value = _guess_initial_step(value)
         self._minuit._last_state.set_error(i, value)
 
 
@@ -1289,7 +1296,7 @@ def _arguments_from_docstring(obj: _tp.Callable) -> _tp.List[str]:
 
 
 def _guess_initial_step(val: float) -> float:
-    return 1e-2 * val if val != 0 else 1e-1  # heuristic
+    return 1e-2 * abs(val) if val != 0 else 1e-1  # heuristic
 
 
 def _key2index_from_slice(var2pos: _tp.Dict[str, int], key: slice) -> _tp.List[int]:

--- a/src/iminuit/version.py
+++ b/src/iminuit/version.py
@@ -7,7 +7,7 @@
 # - Increase MAINTENANCE when fixing bugs without adding features
 # - During development, add suffix .devN with N >= 0
 # - For release candidates, add suffix .rcN with N >= 0
-version = "2.12.1"
+version = "2.12.2"
 
 # We list the corresponding ROOT version of the C++ Minuit2 library here
 root_version = "v6-25-02-1013-ga4bb8f3342"

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1613,3 +1613,18 @@ def test_bad_cl():
 
         with pytest.raises(ValueError):
             m.mncontour("x", "y", cl=cl)
+
+
+def test_negative_errors():
+    m = Minuit(func0, -1, -1)
+    assert np.all(np.array(m.errors) > 0)
+    with pytest.warns():
+        m.errors[0] = -1
+    assert m.errors[0] > 0
+    with pytest.warns():
+        m.errors = -2
+    assert np.all(np.array(m.errors) > 0)
+    m.errors = 10
+    assert_allclose(m.errors, 10)
+    m.errors = (1, 2)
+    assert_allclose(m.errors, (1, 2))


### PR DESCRIPTION
- The internal guess for `Minuit.errors` is to use a fraction of the value. If the value is negative, the error was initialized to a negative value. This patch fixes that mistake.
- Non-positive values assigned to `Minuit.errors` are now rejected. A warning is raised and the invalid value is replaced by the internal heuristic.