### PR TITLE
close mncontour for convenience

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1851,7 +1851,10 @@ class Minuit:
             mnc = MnContours(self._fcn, self._fmin._src, self.strategy)
             ce = mnc(ix, iy, size)[2]
 
-        return np.array(ce)
+        pts = np.array(ce)
+        # add starting point at end to close the contour
+        pts = np.append(pts, pts[:1], axis=0)
+        return pts
 
     def draw_mncontour(
         self,
@@ -1912,9 +1915,6 @@ class Minuit:
         n_lineto = size - 2 if mpl_version < (3, 5) else size - 1
         for cl in cls:
             pts = self.mncontour(x, y, cl=cl, size=size)
-            # add extra point whose coordinates are ignored to close the contour
-            pts = np.append(pts, pts[:1], axis=0)
-
             c_val.append(cl if cl is not None else 0.68)
             c_pts.append([pts])  # level can have more than one contour in mpl
             codes.append([[Path.MOVETO] + [Path.LINETO] * n_lineto + [Path.CLOSEPOLY]])

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1821,10 +1821,8 @@ class Minuit:
         -------
         array of float (N x 2)
             Contour points of the form [[x1, y1]...[xn, yn]].
-            Note that the last point [xn, yn] is not identical to [x1, y1]. To draw a
-            closed contour, please use a closed polygon, like matplotlib.patch.Polygon
-            with the closed=True option, or produce a closed curve by appending the
-            first point at the end of the array.
+            Note that N = size + 1, the last point [xn, yn] is identical to [x1, y1].
+            This makes it easier to draw a closed contour.
 
         See Also
         --------

--- a/src/iminuit/version.py
+++ b/src/iminuit/version.py
@@ -7,7 +7,8 @@
 # - Increase MAINTENANCE when fixing bugs without adding features
 # - During development, add suffix .devN with N >= 0
 # - For release candidates, add suffix .rcN with N >= 0
-version = "2.12.3.beta2"
+# - For beta releases, add suffix .betaN with N >= 0
+version = "2.12.3"
 
 # We list the corresponding ROOT version of the C++ Minuit2 library here
 root_version = "v6-25-02-1013-ga4bb8f3342"

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -637,7 +637,7 @@ def test_mncontour(grad, cl):
         cl = stats.chi2(1).cdf(cl**2)
     factor = stats.chi2(2).ppf(cl)
     cl2 = stats.chi2(1).cdf(factor)
-    assert len(ctr) == 30
+    assert len(ctr) == 31
     assert len(ctr[0]) == 2
 
     m.minos("x", "y", cl=cl2)
@@ -823,7 +823,7 @@ def test_mncontour_array_func():
 
     cl = stats.chi2(2).cdf(1)
     ctr = m.mncontour("x", "y", size=30, cl=cl)
-    assert len(ctr) == 30
+    assert len(ctr) == 31
     assert len(ctr[0]) == 2
 
     m.minos("x", "y")


### PR DESCRIPTION
`Minuit.mncontour` now appends the first point to the end to close the contour, so that it is easier to plot