### PR TITLE
Enhance interactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ cover
 coverage.xml
 
 tests/fig/*.svg
+
+doc/index.rst

--- a/doc/notebooks/basic.ipynb
+++ b/doc/notebooks/basic.ipynb
@@ -1457,6 +1457,8 @@
             "source": [
                 "You can change the parameter values with the sliders. Clicking the \"Fit\" button runs `Minuit.migrad` with these as starting values.\n",
                 "\n",
+                "**Note:** If you see this notebook on ReadTheDocs or otherwise statically rendered, changing the sliders won't change the plot. This requires a running Jupyter kernel.\n",
+                "\n",
                 "Interactive fits are useful to find starting values and to debug the fit. The following issues are easy to detect:\n",
                 "\n",
                 "- Starting values are way off.\n",

--- a/doc/notebooks/interactive.ipynb
+++ b/doc/notebooks/interactive.ipynb
@@ -56,7 +56,7 @@
     "m.limits[\"f\", \"mu\"] = (0, 1)\n",
     "m.limits[\"sigma\", \"slope\"] = (0, None)\n",
     "\n",
-    "m.interactive()"
+    "m.interactive(model_points=10000)"
    ]
   },
   {

--- a/doc/notebooks/interactive.ipynb
+++ b/doc/notebooks/interactive.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Interactive fits\n",
     "\n",
-    "This notebook showcases the interactive fitting capability of iminuit. Interactive fitting is useful to find good starting values and to debug the fit."
+    "This notebook showcases the interactive fitting capability of iminuit. Interactive fitting is useful to find good starting values and to debug the fit.\n",
+    "\n",
+    "**Note:** If you see this notebook on ReadTheDocs or otherwise statically rendered, changing the sliders won't change the plot. This requires a running Jupyter kernel."
    ]
   },
   {
@@ -188,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can pass a custom plotting routine with `Minuit.interactive` to draw more detail."
+    "You can pass a custom plotting routine with `Minuit.interactive` to draw more detail. A simple function works that accesses data from the outer scope, but we create a class in the following example to store the cost function, which has all data we need, because we override the variables in the outer scope in this notebook."
    ]
   },
   {
@@ -197,8 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# a simple function works, but we create a class to \n",
-    "# store the cost function, which has all data we need\n",
+    "# Visualize signal and background components with different colors\n",
     "class Plotter:\n",
     "    def __init__(self, cost):\n",
     "        self.cost = cost\n",

--- a/doc/notebooks/interactive.ipynb
+++ b/doc/notebooks/interactive.ipynb
@@ -358,9 +358,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('venv': venv)",
+   "display_name": "iminuit",
    "language": "python",
-   "name": "python3"
+   "name": "iminuit"
   },
   "language_info": {
    "codemirror_mode": {
@@ -374,7 +374,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.9.13"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "bdbf20ff2e92a3ae3002db8b02bd1dd1b287e934c884beb29a73dced9dbd0fa3"

--- a/doc/notebooks/interactive.ipynb
+++ b/doc/notebooks/interactive.ipynb
@@ -56,7 +56,7 @@
     "m.limits[\"f\", \"mu\"] = (0, 1)\n",
     "m.limits[\"sigma\", \"slope\"] = (0, None)\n",
     "\n",
-    "m.interactive(model_points=10000)"
+    "m.interactive(model_points=1000)"
    ]
   },
   {

--- a/doc/notebooks/interactive.ipynb
+++ b/doc/notebooks/interactive.ipynb
@@ -358,9 +358,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "iminuit",
+   "display_name": "Python 3.9.13 ('venv': venv)",
    "language": "python",
-   "name": "iminuit"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/doc/plots/interactive.py
+++ b/doc/plots/interactive.py
@@ -1,0 +1,21 @@
+from iminuit import Minuit, cost
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+# custom visualization, x and y are taken from outer scope
+def viz(args):
+    plt.plot(x, y, "ok")
+    xm = np.linspace(x[0], x[-1], 100)
+    plt.plot(xm, model(xm, *args))
+
+
+def model(x, a, b):
+    return a + b * x
+
+
+x = np.array([1, 2, 3, 4, 5])
+y = np.array([1.03, 1.58, 2.03, 2.37, 3.09])
+c = cost.LeastSquares(x, y, 0.1, model)
+m = Minuit(c, 0.5, 0.5)
+m.interactive(viz)  # calling m.interactive() uses LeastSquares.visualize

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -567,7 +567,7 @@ class CostSum(Cost, Sequence):
         """Get constituent cost function by index."""
         return self._items.__getitem__(key)
 
-    def visualize(self, args: _ArrayLike, component_kwargs=None):
+    def visualize(self, args: _ArrayLike, component_kwargs=None, **kwargs):
         """
         Visualize data and model agreement (requires matplotlib).
 
@@ -580,11 +580,12 @@ class CostSum(Cost, Sequence):
         ----------
         args : array-like
             Parameter values.
-
         component_kwargs : dict of dicts, optional
-            Optional dict that maps an index to dict of keyword arguments. This can be
+            Dict that maps an index to dict of keyword arguments. This can be
             used to pass keyword arguments to a visualize method of a component with
             that index.
+        **kwargs :
+            Other keyword arguments are forwarded to all components.
         """
         from matplotlib import pyplot as plt
 
@@ -602,8 +603,8 @@ class CostSum(Cost, Sequence):
             if hasattr(comp, "visualize"):
                 i += 1
                 plt.subplot(n, 1, i)
-                kwargs = component_kwargs.get(k, {})
-                comp.visualize(cargs, **kwargs)
+                kwargs2 = kwargs | component_kwargs.get(k, {})
+                comp.visualize(cargs, **kwargs2)
 
 
 class MaskedCost(Cost):
@@ -680,8 +681,8 @@ class UnbinnedCost(MaskedCost):
         ----------
         args : array-like
             Parameter values.
-        xmodel : array-like or None, optional
-            Where to evaluate the model.
+        model_points : int, optional
+            How many points to use to draw the model. Default is 50.
         """
         from matplotlib import pyplot as plt
 
@@ -1420,6 +1421,9 @@ class LeastSquares(MaskedCost):
         ----------
         args : array-like
             Parameter values.
+
+        model_points : int, optional
+            How many points to use to draw the model. Default is 50.
         """
         from matplotlib import pyplot as plt
 

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -567,7 +567,9 @@ class CostSum(Cost, Sequence):
         """Get constituent cost function by index."""
         return self._items.__getitem__(key)
 
-    def visualize(self, args: _ArrayLike, component_kwargs=None, **kwargs):
+    def visualize(
+        self, args: _ArrayLike, component_kwargs: _tp.Dict[int, _tp.Dict] = None
+    ):
         """
         Visualize data and model agreement (requires matplotlib).
 
@@ -603,8 +605,8 @@ class CostSum(Cost, Sequence):
             if hasattr(comp, "visualize"):
                 i += 1
                 plt.subplot(n, 1, i)
-                kwargs2 = kwargs | component_kwargs.get(k, {})
-                comp.visualize(cargs, **kwargs2)
+                kwargs = component_kwargs.get(k, {})
+                comp.visualize(cargs, **kwargs)
 
 
 class MaskedCost(Cost):

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2133,10 +2133,10 @@ class Minuit:
                     continuous_update=True,
                 )
                 self.fix = ToggleButton(
-                    fix, description="Fixed", layout=Layout(width="5em")
+                    fix, description="Fix", layout=Layout(width="3.1em")
                 )
                 self.opt = ToggleButton(
-                    False, description="Opt", layout=self.fix.layout
+                    False, description="Opt", layout=Layout(width="3.5em")
                 )
                 self.opt.observe(self.on_opt_toggled, "value")
                 super().__init__([self.slider, self.fix, self.opt])

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2127,8 +2127,19 @@ class Minuit:
             try:
                 with warnings.catch_warnings():
                     plot(args, **kwargs)
-            except Exception as e:
-                plt.text(0.5, 0.5, str(e), transform=trans)
+            except Exception:
+                import traceback
+
+                plt.figtext(
+                    0.01,
+                    0.5,
+                    traceback.format_exc(),
+                    ha="left",
+                    va="center",
+                    transform=trans,
+                    color="r",
+                )
+                return
             if from_fit:
                 fval = self.fmin.fval
             else:
@@ -2184,7 +2195,7 @@ class Minuit:
                 self.simplex()
                 return False
             else:
-                assert False  # should never happen
+                assert False  # pragma: no cover, should never happen
             return True
 
         def on_slider_change(change):

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1446,35 +1446,3 @@ def _show_inline_matplotlib_plots():
         or mpl.get_backend() == "module://matplotlib_inline.backend_inline"
     ):
         flush_figures()  # pragma: no cover
-
-
-def _smart_sampling(f, xmin, xmax, start=17, sub=3, atol=1e-3, rtol=np.inf):
-    from scipy.interpolate import interp1d
-
-    x = np.linspace(xmin, xmax, start)
-    y = {xi: f(xi) for xi in x}
-    x_intervals = [(x[i], x[i + 1]) for i in range(start - 1)]
-    while len(x_intervals):
-        if len(y) > 10000:
-            warnings.warn("Too many points", RuntimeWarning)
-            break
-        xint = x_intervals.pop()
-        xsub = np.linspace(*xint, sub)
-        xnew = xsub[1:-1]
-        ynew = f(xnew)
-        # TODO replace with custom interpolation
-        yint = interp1d(xint, [y[xi] for xi in xint])(xnew)
-        for xi, yi in zip(xnew, ynew):
-            y[xi] = yi
-        dy = ynew - yint
-        cond = True
-        if np.isfinite(atol):
-            cond &= np.abs(dy) > atol
-        if np.isfinite(rtol):
-            cond &= np.abs(dy) > rtol * np.abs(ynew)
-        if np.any(cond):
-            for i in range(sub - 1):
-                x_intervals.append((xsub[i], xsub[i + 1]))
-    xy = list(y.items())
-    xy.sort()
-    return np.transpose(xy)

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1446,3 +1446,35 @@ def _show_inline_matplotlib_plots():
         or mpl.get_backend() == "module://matplotlib_inline.backend_inline"
     ):
         flush_figures()  # pragma: no cover
+
+
+def _smart_sampling(f, xmin, xmax, start=17, sub=3, atol=1e-3, rtol=np.inf):
+    from scipy.interpolate import interp1d
+
+    x = np.linspace(xmin, xmax, start)
+    y = {xi: f(xi) for xi in x}
+    x_intervals = [(x[i], x[i + 1]) for i in range(start - 1)]
+    while len(x_intervals):
+        if len(y) > 10000:
+            warnings.warn("Too many points", RuntimeWarning)
+            break
+        xint = x_intervals.pop()
+        xsub = np.linspace(*xint, sub)
+        xnew = xsub[1:-1]
+        ynew = f(xnew)
+        # TODO replace with custom interpolation
+        yint = interp1d(xint, [y[xi] for xi in xint])(xnew)
+        for xi, yi in zip(xnew, ynew):
+            y[xi] = yi
+        dy = ynew - yint
+        cond = True
+        if np.isfinite(atol):
+            cond &= np.abs(dy) > atol
+        if np.isfinite(rtol):
+            cond &= np.abs(dy) > rtol * np.abs(ynew)
+        if np.any(cond):
+            for i in range(sub - 1):
+                x_intervals.append((xsub[i], xsub[i + 1]))
+    xy = list(y.items())
+    xy.sort()
+    return np.transpose(xy)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -157,7 +157,7 @@ def test_interactive():
 
         def __call__(self, args):
             self.n += 1
-            if self.n > 5:
+            if self.n > 6:
                 raise ValueError("foo")
 
     plot = Plot()
@@ -177,13 +177,19 @@ def test_interactive():
         assert plot.n == 1
 
         # manipulate state to also check this code
-        out1.children[1].children[0].children[0].click()  # click on Fit
+        ui = out1.children[1]
+        header, parameters = ui.children
+        fit_button, update_button = header.children
+        fit_button.click()  #
         assert_allclose(m.values, (0, 0), atol=1e-5)
-
-        out1.children[1].children[0].children[1].value = False  # toggle on Update
         assert plot.n == 2
-        out1.children[1].children[1].children[0].value = 0.4  # change first slider
+
+        update_button.value = False
+        parameters.children[0].slider.value = 0.4  # change first slider
         assert plot.n == 3
+        parameters.children[0].fix.value = True
+        parameters.children[0].opt.value = True
+        assert plot.n == 4
 
         class Cost:
             def visualize(self, args):
@@ -195,16 +201,19 @@ def test_interactive():
         c = Cost()
         m = Minuit(c, 0, 0)
         out2 = m.interactive()
-        assert plot.n == 4
+        assert plot.n == 5
 
         # this should modify slider range
-        assert out2.children[1].children[1].children[0].max < 100
-        assert out2.children[1].children[1].children[1].min > -100
-        out2.children[1].children[0].children[0].click()  # click on Fit
+        ui = out2.children[1]
+        header, parameters = ui.children
+        fit_button, update_button = header.children
+        assert parameters.children[0].slider.max < 100
+        assert parameters.children[1].slider.min > -100
+        fit_button.click()
         assert_allclose(m.values, (100, -100), atol=1e-5)
-        assert plot.n == 5
+        assert plot.n == 6
         # this should trigger an exception
-        out2.children[1].children[0].children[0].click()  # click on Fit
+        fit_button.click()
 
     except ModuleNotFoundError:
         ipywidgets_available = False


### PR DESCRIPTION
See #767

- Minuit.interactive
  - Added Fix and Opt toggle buttons for each parameter. If Fix is toggled, clicking on Fit will not change this parameter, but the slider is still enabled. If Opt is toggled, the corresponding slider gets disabled and its value will be chosen by Minuit so that it minimizes the cost function.
  - Keyword arguments are now forwarded to the plot function, which defaults to the visualize method of the cost function. Use this to adjust the visualization.
  - Added Reset button
  - Added Dropdown menu to select fitting algorithm
- Added parameter `model_points` to method `visualize` of `UnbinnedNLL`, `ExtendedUnbinnedNLL`, `LeastSquares` to change how many points are generated for the model
