### PR TITLE
Improve docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
 # Makefile for developers with some convenient quick ways to do common things
 
 # default target
-build/done: $(wildcard *.py src/*.cpp extern/root/math/minuit2/src/*.cxx extern/root/math/minuit2/inc/*.h) CMakeLists.txt
+build/done: build/deps $(wildcard *.py src/*.cpp extern/root/math/minuit2/src/*.cxx extern/root/math/minuit2/inc/*.h) CMakeLists.txt
 	DEBUG=1 python -m pip install -v -e .
 	touch build/done
 
 test: build/done
 	python -m pytest -vv -r a --ff --pdb
 
+build/deps:
+	# (re-)install all test dependencies
+	python .ci/install_extra.py
+	touch build/deps
+
 cov: build/done
 	# only computes the coverage in pure Python
 	rm -rf htmlcov
-	# (re-)install all test dependencies
-	python .ci/install_extra.py
 	coverage run -m pytest
 	python -m pip uninstall --yes numba ipykernel ipywidgets
 	coverage run --append -m pytest
 	python -m pip uninstall --yes scipy matplotlib
 	coverage run --append -m pytest
 	coverage html -d htmlcov
+	rm build/deps
 
 doc: build/done build/html/done
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,7 @@ nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
     "--InlineBackend.rc=figure.dpi=96",
 ]
+# nbsphinx_execute = "never"  # uncomment this to speed up doc build
 
 autoclass_content = "both"
 autosummary_generate = True

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -36,16 +36,15 @@ Minuit
 .. autoclass:: Minuit
     :members:
 
+Scipy-like interface
+--------------------
+
+.. autofunction:: minimize
+
 Cost functions
 --------------
 
 .. automodule:: iminuit.cost
-    :members:
-
-Scipy-like interface
---------------------
-
-.. automodule:: iminuit.minimize
     :members:
 
 Utilities

--- a/src/iminuit/minimize.py
+++ b/src/iminuit/minimize.py
@@ -1,11 +1,4 @@
-"""
-Scipy interface for Minuit.
-
-The :func:`minimize` function provides the same interface as ``scipy.optimize.minimize``.
-If you are familiar with the latter, this allows you to use Minuit with a quick start.
-Eventually, you still may want to learn the interface of the :class:`Minuit` class, as it
-provides more functionality if you are interested in parameter uncertainties.
-"""
+"""Scipy interface for Minuit."""
 
 from .minuit import Minuit
 import warnings
@@ -29,32 +22,41 @@ def minimize(
     """
     Interface to MIGRAD using the ``scipy.optimize.minimize`` API.
 
-    For a general description of the arguments, see ``scipy.optimize.minimize``.
+    This function provides the same interface as ``scipy.optimize.minimize``.
+    If you are familiar with the latter, this allows you to use Minuit with a quick start.
+    Eventually, you still may want to learn the interface of the :class:`Minuit` class,
+    as it provides more functionality if you are interested in parameter uncertainties.
 
-    Allowed values for ``method`` are "migrad" or "simplex". Default: "migrad".
+    For a general description of the arguments of this function, see
+    ``scipy.optimize.minimize``. We list only a few in the following.
 
-    The ``options`` argument can be used to pass special settings to Minuit.
-    All are optional.
-
-    **Options:**
-
-      - *disp* (bool): Set to true to print convergence messages. Default: False.
-      - *stra* (int): Minuit strategy (0: fast/inaccurate, 1: balanced,
+    Parameters
+    ----------
+    method: str
+        Allowed values are "migrad" or "simplex". Default: "migrad".
+    options: dict
+        Can be used to pass special settings to Minuit. All are optional.
+        The following options are supported.
+        *disp* (bool): Set to true to print convergence messages. Default: False.
+        *stra* (int): Minuit strategy (0: fast/inaccurate, 1: balanced,
         2: slow/accurate). Default: 1.
-      - *maxfun* (int): Maximum allowed number of iterations. Default: None.
-      - *maxfev* (int): Deprecated alias for *maxfun*.
-      - *eps* (sequence): Initial step size to numerical compute derivative.
+        *maxfun* (int): Maximum allowed number of iterations. Default: None.
+        *maxfev* (int): Deprecated alias for *maxfun*.
+        *eps* (sequence): Initial step size to numerical compute derivative.
         Minuit automatically refines this in subsequent iterations and is very
         insensitive to the initial choice. Default: 1.
 
-    **Returns: OptimizeResult** (dict with attribute access)
-      - *x* (ndarray): Solution of optimization.
-      - *fun* (float): Value of objective function at minimum.
-      - *message* (str): Description of cause of termination.
-      - *hess_inv* (ndarray): Inverse of Hesse matrix at minimum (may not be exact).
-      - nfev (int): Number of function evaluations.
-      - njev (int): Number of jacobian evaluations.
-      - minuit (object): Minuit object internally used to do the minimization.
+    Returns
+    -------
+    OptimizeResult
+        Dict with attribute access that holds the result. It contains the following
+        lists of fields. *x* (ndarray): Solution of optimization.
+        *fun* (float): Value of objective function at minimum.
+        *message* (str): Description of cause of termination.
+        *hess_inv* (ndarray): Inverse of Hesse matrix at minimum (may not be exact).
+        *nfev* (int): Number of function evaluations.
+        *njev* (int): Number of jacobian evaluations.
+        *minuit* (Minuit): Minuit object internally used to do the minimization.
         Use this to extract more information about the parameter errors.
     """
     from scipy.optimize import OptimizeResult, Bounds


### PR DESCRIPTION
Closes #775

The docs now show `iminuit.minimize` instead of `iminuit.minimize.minimize` in the reference, consistent with `iminuit.Minuit` instead of `iminuit.minuit.Minuit`. The formatting of the docstring for `minimize` was improved.