### PR TITLE
Comparison with broadcast

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -95,7 +95,7 @@ class BasicView(abc.ABC):
         """Return true if all values are equal."""
         try:
             a, b = np.broadcast_arrays(self, other)  # type:ignore
-            return np.all(a == b)  # type:ignore
+            return np.all(a == b)  # type:ignore # got _bool, expected bool
         except Exception:
             return NotImplemented
 

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -15,6 +15,8 @@ from time import monotonic
 import warnings
 import sys
 
+_ArrayLike = _tp.Sequence
+
 
 class IMinuitWarning(RuntimeWarning):
     """Generic iminuit warning."""
@@ -93,11 +95,8 @@ class BasicView(abc.ABC):
 
     def __eq__(self, other: object) -> bool:
         """Return true if all values are equal."""
-        try:
-            a, b = np.broadcast_arrays(self, other)  # type:ignore
-            return np.all(a == b)  # type:ignore # got _bool, expected bool
-        except Exception:
-            return NotImplemented
+        a, b = np.broadcast_arrays(self, other)  # type:ignore
+        return _tp.cast(bool, np.all(a == b))
 
     def __repr__(self) -> str:
         """Get detailed text representation."""

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -93,9 +93,11 @@ class BasicView(abc.ABC):
 
     def __eq__(self, other: object) -> bool:
         """Return true if all values are equal."""
-        if isinstance(other, _tp.Iterable) and isinstance(other, _tp.Sized):
-            return len(self) == len(other) and all(x == y for x, y in zip(self, other))
-        return NotImplemented
+        try:
+            a, b = np.broadcast_arrays(self, other)
+            return np.all(a == b)
+        except Exception:
+            return NotImplemented
 
     def __repr__(self) -> str:
         """Get detailed text representation."""

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -94,8 +94,8 @@ class BasicView(abc.ABC):
     def __eq__(self, other: object) -> bool:
         """Return true if all values are equal."""
         try:
-            a, b = np.broadcast_arrays(self, other)
-            return np.all(a == b)
+            a, b = np.broadcast_arrays(self, other)  # type:ignore
+            return np.all(a == b)  # type:ignore
         except Exception:
             return NotImplemented
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -103,6 +103,30 @@ def test_FixedView_as_mask_for_other_views():
     assert_equal(v, [2, 5, 4])
 
 
+def test_FixedView_comparison_with_broadcasting():
+    state = MnUserParameterState()
+    state.add("x", 1, 0.1)
+    state.add("y", 2, 0.1)
+    state.add("z", 3, 0.1)
+
+    fake_minuit = Namespace(
+        _var2pos={"x": 0, "y": 1, "z": 2},
+        _pos2var=("x", "y", "z"),
+        npar=3,
+        _last_state=state,
+        _copy_state_if_needed=lambda: None,
+    )
+
+    f = util.FixedView(fake_minuit)
+
+    assert_equal(f, [False, False, False])
+
+    # broadcasting
+    assert f == False
+    f.fixed[0] = True
+    assert f != False
+
+
 def test_Matrix():
     m = util.Matrix(("a", "b"))
     m[:] = [[1, 2], [2, 8]]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -123,7 +123,8 @@ def test_FixedView_comparison_with_broadcasting():
 
     # broadcasting
     assert f == False
-    f.fixed[0] = True
+    f[0] = True
+    assert_equal(f, [True, False, False])
     assert f != False
 
 


### PR DESCRIPTION
Broadcasting support for BasicView. Allows for example `np.all(m.fixed == False)`