### PR TITLE
Add Python 3.11, drop 3.6

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
         submodules: true
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.9"
     - run: python -m pip install --upgrade pip
     - run: python -m pip install --prefer-binary -e .[test]
     - run: coverage run -m pytest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
         submodules: true
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.9"
     - run: sudo apt-get install pandoc
     - run: python -m pip install --upgrade pip wheel
     - run: python -m pip install --prefer-binary -v .[doc,test]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.9"
 
     - run: python -m pip install --upgrade pip wheel
     - run: python -m pip install pre-commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [auto, aarch64]
-        py: [cp36, cp37, cp38, cp39, cp310, cp311]
+        py: [cp37, cp38, cp39, cp310, cp311]
         include:
           - os: macos-latest
             py: cp38

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [auto, aarch64]
-        py: [cp36, cp37, cp38, cp39, cp310]
+        py: [cp36, cp37, cp38, cp39, cp310, cp311]
         include:
           - os: macos-latest
             py: cp38

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
 
     strategy:
       matrix:
+        python-version: ["3.11-dev"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         include:
           # version number must be string, otherwise 3.10 becomes 3.1
           - os: windows-latest
@@ -23,7 +25,7 @@ jobs:
             python-version: "pypy-3.7"
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
         include:
           # version number must be string, otherwise 3.10 becomes 3.1
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11-dev"
           - os: macos-latest
-            python-version: "3.6"
+            python-version: "3.7"
           - os: ubuntu-latest
             python-version: "pypy-3.7"
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ filterwarnings = [
 
 [tool.cibuildwheel]
 # update skip when numpy wheels become available
-skip = ["*-musllinux_*", "cp310-win32", "cp310-manylinux_i686"]
+skip = ["*-musllinux_*", "cp31?-win32", "cp31?-manylinux_i686"]
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 test-skip = ["*universal2:arm64"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Programming Language :: C++
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ classifiers =
 package_dir =
     = src
 packages = iminuit
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires = numpy
 
 [options.extras_require]


### PR DESCRIPTION
Updating to add Python 3.11. For the moment, this adds all three OS's for 3.11, can be scaled back when the PR tests pass.

FYI, trying to roll out 3.11 support in Hist and iminuit's a testing dependency.