### PR TITLE
Add dependabot to keep actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Many of the actions are quite out of date; using dependabot (and I've set a monthly setting to keep the number of updates down) would really help keep the actions fresh & active. See most of the other scikit-hep repos for examples of working dependabot files. Dependabot recently became smart enough to only do "matching" updates; v2 -> v3 and not v3.0.1 or something like that.
