### PR TITLE
Fix typo "probility"→ "probability" in minos docstring

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1380,7 +1380,7 @@ class Minuit:
         Notes
         -----
         Asymptotically (large samples), the Minos interval has a coverage probability
-        equal to the given confidence level. The coverage probability is the probility for
+        equal to the given confidence level. The coverage probability is the probability for
         the interval to contain the true value in repeated identical experiments.
 
         The interval is invariant to transformations and thus not distorted by parameter


### PR DESCRIPTION
Found the typo in the online documentation.

My only question is whether I should reflow the paragraph,  because my typo fix resulted in a line length of 90 instead, whereas most lines seem to be 88 chars long. However I installed pre-commit and surprisingly the commit passed the checks, therefore I didn't bother, also in the interest of keeping the diff trivial.