### PR TITLE
docs: Use 'req@url' syntax to install from remote VCS

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -38,7 +38,7 @@ For users
 
 If you need the latest unreleased version, you can download and install directly from Github. The easiest way is to use pip.
 
-    pip install git+https://github.com/scikit-hep/iminuit@develop#egg=iminuit
+    pip install iminuit@git+https://github.com/scikit-hep/iminuit@develop
 
 This requires a C++ compiler with C++14 support.
 


### PR DESCRIPTION
Use 'req@url' syntax when using pip to install from a remote git repository over 'url#egg=req' to avoid the use of #egg= fragments with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. https://github.com/pypa/pip/pull/11617 for more details