### PR TITLE
fix template input modification bug in Template class

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -1272,12 +1272,12 @@ class Template(BinnedCost):
                     # template is weighted
                     if tt.ndim != ndim + 1 or tt.shape[:-1] != shape:
                         raise ValueError("shapes of n and templates do not match")
-                    t1 = tt[..., 0]
-                    t2 = tt[..., 1]
+                    t1 = tt[..., 0].copy()
+                    t2 = tt[..., 1].copy()
                 else:
                     if tt.ndim != ndim or tt.shape != shape:
                         raise ValueError("shapes of n and templates do not match")
-                    t1 = tt
+                    t1 = tt.copy()
                     t2 = tt.copy()
                 # normalize to unity
                 f = 1 / np.sum(t1)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1182,6 +1182,27 @@ def test_Template(method):
         assert_allclose(m.values, [2, 4], atol=1e-2)
 
 
+@pytest.mark.parametrize(
+    "template",
+    (
+        (np.array([1.0, 1.0, 0.0]), np.array([0.0, 1.0, 3.0])),
+        (
+            np.array([[1.0, 1.0], [1.0, 1.0], [0.0, 0.0]]),
+            np.array([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0]]),
+        ),
+    ),
+)
+def test_Template_does_not_modify_inputs(template):
+    from copy import deepcopy
+
+    xe = np.array([0, 1, 2, 3])
+    template_copy = deepcopy(template)
+    n = template[0] + template[1]
+
+    Template(n, xe, template, method="da")
+    assert_equal(template, template_copy)
+
+
 def generate(rng, nmc, truth, bins, tf=1, df=1):
     xe = np.linspace(0, 2, bins + 1)
     b = np.diff(truncexpon(1, 0, 2).cdf(xe))


### PR DESCRIPTION
Under certain circumstances, class Template modified the template input arrays *inplace*, which should not happen.

This fixes the bug and adds a test that exposed the bug.

Thanks to @zjkjsd who reported this in #825 