### PR TITLE
Ignore missing matplotlib when calling Minuit._repr_html_()

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2523,8 +2523,18 @@ class Minuit:
             s += self.covariance._repr_html_()
         if self.fmin is not None:
             try:
-                s += self.visualize()._repr_html_()
-            except (AttributeError, ValueError):
+                import matplotlib as mpl
+                import matplotlib.pyplot as plt
+                import io
+
+                with mpl.rc_context({"interactive": False}):
+                    with _TemporaryFigure():
+                        self.visualize()
+                        with io.StringIO() as io:
+                            plt.savefig(io, format="svg")
+                            io.seek(0)
+                            s += io.read()
+            except (ModuleNotFoundError, AttributeError, ValueError):
                 pass
         return s
 
@@ -2680,6 +2690,20 @@ class _TemporaryErrordef:
 
     def __exit__(self, *args: object) -> None:
         self.fcn._errordef = self.saved
+
+
+class _TemporaryFigure:
+    def __init__(self):
+        from matplotlib import pyplot as plt
+
+        self.plt = plt
+        self.plt.figure()
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, *args: object) -> None:
+        self.plt.close()
 
 
 def _cl_to_errordef(cl, npar, default):

--- a/tests/test_without_matplotlib.py
+++ b/tests/test_without_matplotlib.py
@@ -1,0 +1,18 @@
+from iminuit import cost
+from iminuit._hide_modules import hide_modules
+import pytest
+
+pytest.importorskip("matplotlib.pyplot")
+
+
+def test_visualize():
+    import iminuit
+
+    c = cost.LeastSquares([1, 2], [3, 4], 1, lambda x, a: a * x)
+
+    s = iminuit.Minuit(c, 1).migrad()._repr_html_()
+    assert "<svg" in s
+
+    with hide_modules("matplotlib", reload="iminuit"):
+        s = iminuit.Minuit(c, 1).migrad()._repr_html_()
+        assert "<svg" not in s


### PR DESCRIPTION
Closes #866 

If matplotlib is not installed, `Minuit._repr_html_()` now quietly skips plotting the figure. The generated figure is now really part of the html code returned by this method.