### PR TITLE
Rename keyword nbins to bins in UnbinnedCost.visualize

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -86,6 +86,7 @@ from typing import (
     overload,
 )
 import warnings
+from ._deprecated import deprecated_parameter
 
 __all__ = [
     "CHISQUARE",
@@ -819,7 +820,8 @@ class UnbinnedCost(MaskedCost):
         # unbinned likelihoods have infinite degrees of freedom
         return np.inf
 
-    def visualize(self, args: Sequence[float], model_points: int = 0, nbins: int = 50):
+    @deprecated_parameter(bins="nbins")
+    def visualize(self, args: Sequence[float], model_points: int = 0, bins: int = 50):
         """
         Visualize data and model agreement (requires matplotlib).
 
@@ -832,7 +834,7 @@ class UnbinnedCost(MaskedCost):
         model_points : int, optional
             How many points to use to draw the model. Default is 0, in this case
             an smart sampling algorithm selects the number of points.
-        nbins : int, optional
+        bins : int, optional
             number of bins. Default is 50 bins.
 
         """
@@ -841,7 +843,7 @@ class UnbinnedCost(MaskedCost):
         if self.data.ndim > 1:
             raise ValueError("visualize is not implemented for multi-dimensional data")
 
-        n, xe = np.histogram(self.data, bins=nbins)
+        n, xe = np.histogram(self.data, bins=bins)
         cx = 0.5 * (xe[1:] + xe[:-1])
         plt.errorbar(cx, n, n**0.5, fmt="ok")
         if model_points > 0:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -229,7 +229,7 @@ def test_UnbinnedNLL_visualize(log):
     # linear spacing
     c.visualize((1, 2), model_points=10)
     # linear spacing and different binning
-    c.visualize((1, 2), model_points=10, nbins=20)
+    c.visualize((1, 2), model_points=10, bins=20)
     # trigger log-spacing
     c = UnbinnedNLL([1, 1000], norm_logpdf if log else norm_pdf, log=log)
     c.visualize((1, 2), model_points=10)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -233,7 +233,11 @@ def test_UnbinnedNLL_visualize(log):
     # trigger log-spacing
     c = UnbinnedNLL([1, 1000], norm_logpdf if log else norm_pdf, log=log)
     c.visualize((1, 2), model_points=10)
-    c.visualize((1, 2), model_points=10, nbins=20)
+    c.visualize((1, 2), model_points=10, bins=20)
+    with pytest.raises(
+        np.VisibleDeprecationWarning, match="keyword 'nbins' is deprecated"
+    ):
+        c.visualize((1, 2), nbins=20)
 
 
 def test_UnbinnedNLL_visualize_2D():


### PR DESCRIPTION
`bins` is the standard keyword in numpy, matplotlib.