### PR TITLE
Fix tests on FreeBSD, remove util._jacobi

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -996,6 +996,7 @@ class Minuit:
                 Bounds,
                 NonlinearConstraint,
                 LinearConstraint,
+                approx_fprime,
             )
         except ModuleNotFoundError as exc:
             exc.msg += "\n\nPlease install scipy to use scipy minimizers in iminuit."
@@ -1273,7 +1274,7 @@ class Minuit:
         else:
             tol = 1e-2
             dx = np.sqrt(np.diag(matrix) * tol)
-            jac = mutil._jacobi(fcn, r.x, dx, tol)[1][0]
+            jac = approx_fprime(r.x, fcn, epsilon=dx)
 
         edm_goal = self._edm_goal(migrad_factor=True)
         fm = FunctionMinimum(

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1272,8 +1272,7 @@ class Minuit:
         elif "jac" in r:
             jac = r.jac
         else:
-            tol = 1e-2
-            dx = np.sqrt(np.diag(matrix) * tol)
+            dx = np.sqrt(np.diag(matrix) * 1e-10)
             jac = approx_fprime(r.x, fcn, epsilon=dx)
 
         edm_goal = self._edm_goal(migrad_factor=True)

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -949,6 +949,7 @@ class MErrors(OrderedDict):
         return OrderedDict.__getitem__(self, key)
 
 
+@_deprecated.deprecated("use jacobi.jacobi instead from jacobi library")
 def _jacobi(
     fn: Callable, x: NDArray, dx: NDArray, tol: float, debug: bool = False
 ) -> Tuple[NDArray, NDArray]:

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -949,61 +949,6 @@ class MErrors(OrderedDict):
         return OrderedDict.__getitem__(self, key)
 
 
-@_deprecated.deprecated("use jacobi.jacobi instead from jacobi library")
-def _jacobi(
-    fn: Callable, x: NDArray, dx: NDArray, tol: float, debug: bool = False
-) -> Tuple[NDArray, NDArray]:
-    assert x.ndim == 1
-    assert dx.ndim == 1
-    assert np.all(dx >= 0)
-    assert tol > 0
-    y = fn(x)
-    yrank = np.ndim(y)
-    jac = np.zeros((1 if yrank == 0 else len(y), len(x)))
-    h = np.zeros(len(x))
-    divergence = True
-    for i, hi in enumerate(dx):
-        if i > 0:
-            h[i - 1] = 0
-        if hi == 0:
-            continue
-        h[i] = hi
-        prev_esq = np.inf
-        for iter in range(20):
-            assert h[i] > 0
-            yu = fn(x + h)
-            yd = fn(x - h)
-            du = (yu - y) / h[i]
-            dd = (y - yd) / h[i]
-            d = 0.5 * (du + dd)
-            delta = du - dd
-            if np.all(np.abs(delta) <= tol * np.abs(d)):
-                if debug:
-                    print(
-                        f"jacobi: iter={iter} converged; delta={delta} "
-                        f"threshold={tol * np.abs(d)}"
-                    )
-                jac[:, i] = d
-                break
-            esq = np.dot(delta, delta)
-            if debug:
-                print(f"jacobi: iter={iter} d={d} esq={esq} h={h}")
-            if iter > 0 and esq < prev_esq:
-                divergence = False
-            if esq >= prev_esq:
-                if divergence:
-                    print(f"jacobi: iter={iter} divergence detected")
-                    jac[:, i] = np.nan
-                else:
-                    print(f"jacobi: iter={iter} no convergence")
-                    # no convergence, use previous more accurate jac[:, i]
-                break
-            jac[:, i] = d
-            prev_esq = esq
-            h[i] *= 0.1
-    return y, jac
-
-
 @_deprecated.deprecated("use jacobi.propagate instead from jacobi library")
 def propagate(
     fn: Callable,
@@ -1032,17 +977,20 @@ def propagate(
         y is the result of fn(x)
         ycov is the propagated covariance matrix.
     """
+    from scipy.optimize import approx_fprime
+
     vx = np.atleast_1d(x)  # type:ignore
     if np.ndim(cov) != 2:  # type:ignore
         raise ValueError("cov must be 2D array-like")
     vcov = np.atleast_2d(cov)  # type:ignore
     if vcov.shape[0] != vcov.shape[1]:
         raise ValueError("cov must have shape (N, N)")
-    tol = 1e-2
+    tol = 1e-10
     dx = (np.diag(vcov) * tol) ** 0.5
     if not np.all(dx >= 0):
         raise ValueError("diagonal elements of covariance matrix must be non-negative")
-    y, jac = _jacobi(fn, vx, dx, tol)
+    y = fn(vx)
+    jac = np.atleast_2d(approx_fprime(vx, fn, dx))
     ycov = np.einsum("ij,kl,jl", jac, jac, vcov)
     return y, np.squeeze(ycov) if np.ndim(y) == 0 else ycov
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,7 @@ from iminuit._core import MnUserParameterState
 from iminuit._optional_dependencies import optional_module_for
 import pickle
 from iminuit._hide_modules import hide_modules
+import platform
 
 
 def test_ndim():
@@ -606,7 +607,8 @@ def test_jacobi():
     dx = np.abs(x) * 1e-3 + 1e-3
     tol = 1e-3
 
-    y, jac = util._jacobi(np.exp, x, dx, tol)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(np.exp, x, dx, tol)
     np.testing.assert_equal(y, np.exp(x))
     jac_ref = np.zeros((n, n))
     for i in range(n):
@@ -615,7 +617,8 @@ def test_jacobi():
 
     x = np.linspace(1e-10, 5, n)
     dx = np.abs(x) * 1e-3
-    y, jac = util._jacobi(np.log, x, dx, tol)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(np.log, x, dx, tol)
     jac_ref = np.zeros((n, n))
     for i in range(n):
         jac_ref[i, i] = 1 / x[i]
@@ -625,21 +628,24 @@ def test_jacobi():
 def test_jacobi_on_bad_input():
     x = np.array([1])
     dx = np.array([0.1])
-    y, jac = util._jacobi(lambda x: np.nan, x, dx, 1e-3)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(lambda x: np.nan, x, dx, 1e-3)
 
     np.testing.assert_equal(y, np.nan)
     np.testing.assert_equal(jac, np.nan)
 
     x = np.array([1])
     dx = np.array([0])
-    y, jac = util._jacobi(lambda x: x**2, x, dx, 1e-3)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(lambda x: x**2, x, dx, 1e-3)
 
     np.testing.assert_equal(y, 1)
     np.testing.assert_equal(jac, 0)
 
     x = np.array([np.nan])
     dx = np.array([0.1])
-    y, jac = util._jacobi(lambda x: x**2, x, dx, 1e-3)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(lambda x: x**2, x, dx, 1e-3)
 
     np.testing.assert_equal(y, np.nan)
     np.testing.assert_equal(jac, np.nan)
@@ -648,21 +654,26 @@ def test_jacobi_on_bad_input():
     dx = np.array([np.nan])
     with pytest.raises(AssertionError):
         # dx must be >= 0
-        util._jacobi(lambda x: x**2, x, dx, 1e-3)
+        with pytest.warns(np.VisibleDeprecationWarning):
+            util._jacobi(lambda x: x**2, x, dx, 1e-3)
 
 
 @pytest.mark.parametrize("fail", (False, True))
+@pytest.mark.skipif(
+    platform.system() == "FreeBSD", reason="Fails on FreeBSD 13.2, see issue 901"
+)
 def test_jacobi_low_resolution(fail, capsys):
     x = np.array([1])
     dx = np.array([1])
 
-    y, jac = util._jacobi(
-        lambda x: np.exp(x.astype(np.float32)),
-        x,
-        dx,
-        1e-10 if fail else 1e-3,
-        debug=True,
-    )
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(
+            lambda x: np.exp(x.astype(np.float32)),
+            x,
+            dx,
+            1e-10 if fail else 1e-3,
+            debug=True,
+        )
 
     assert fail == ("no convergence" in capsys.readouterr()[0])
 
@@ -676,7 +687,8 @@ def test_jacobi_divergence_1(capsys):
     x = np.array([1])
     dx = np.array([1])
 
-    y, jac = util._jacobi(lambda x: rng.normal(), x, dx, 0.1, debug=True)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(lambda x: rng.normal(), x, dx, 0.1, debug=True)
 
     assert "divergence" in capsys.readouterr()[0]
 
@@ -688,7 +700,8 @@ def test_jacobi_divergence_2(capsys):
     x = np.array([1e-10])
     dx = np.array([0.1])
 
-    y, jac = util._jacobi(lambda x: 1 / x, x, dx, 1e-3, debug=True)
+    with pytest.warns(np.VisibleDeprecationWarning):
+        y, jac = util._jacobi(lambda x: 1 / x, x, dx, 1e-3, debug=True)
 
     assert "divergence" in capsys.readouterr()[0]
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,13 @@ from iminuit._optional_dependencies import optional_module_for
 import pickle
 from iminuit._hide_modules import hide_modules
 
+try:
+    import scipy  # noqa
+
+    scipy_available = True
+except ModuleNotFoundError:
+    scipy_available = False
+
 
 def test_ndim():
     ndim = util._ndim
@@ -511,6 +518,7 @@ def test_merge_signatures():
     assert pg == (0, 3, 4)
 
 
+@pytest.mark.skipif(not scipy_available, reason="needs scipy")
 def test_propagate_1():
     cov = [
         [1.0, 0.1, 0.2],
@@ -535,6 +543,7 @@ def test_propagate_1():
     np.testing.assert_allclose(ycov, 8, rtol=1e-3)
 
 
+@pytest.mark.skipif(not scipy_available, reason="needs scipy")
 def test_propagate_2():
     cov = [
         [1.0, 0.1, 0.2],
@@ -563,6 +572,7 @@ def test_propagate_2():
     np.testing.assert_allclose(ycov, np.einsum("i,k,ik", jac, jac, cov), rtol=1e-3)
 
 
+@pytest.mark.skipif(not scipy_available, reason="needs scipy")
 def test_propagate_3():
     # matrices with full zero rows and columns are supported
     cov = [
@@ -581,6 +591,7 @@ def test_propagate_3():
     np.testing.assert_allclose(ycov, [[4, 0.0, 0.8], [0.0, 0.0, 0.0], [0.8, 0.0, 12]])
 
 
+@pytest.mark.skipif(not scipy_available, reason="needs scipy")
 def test_propagate_on_bad_input():
     cov = [[np.nan, 0.0], [0.0, 1.0]]
     x = [1.0, 2.0]


### PR DESCRIPTION
Closes #901

The private function `iminuit.util._jacobi` is removed without deprecation. It was internally replaced by `scipy.optimize.approx_fprime`. Those who used `_jacobi` for some reason should switch to `jacobi.jacobi` from the `jacobi` package if a high-accuracy derivative is required or use `scipy.optimize_approx_fprime` for a low-accuracy derivative.