### PR TITLE
fix: SDist size reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ tests/fig/*.svg
 doc/index.rst
 
 testcase
+
+*venv*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,13 @@ doc = [
 [tool.scikit-build]
 minimum-version = "0.3"
 build-dir = "build/{wheel_tag}"
+sdist.exclude = [
+    "extern/root",
+]
+sdist.include = [
+    "extern/root/math/minuit2/inc",
+    "extern/root/math/minuit2/src",
+]
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
This reduces the size of the SDist from 160 MB to 2.2 MB (mostly docs, notebooks, and tests, I expect). (Previously this was done at https://github.com/scikit-hep/iminuit/blob/v2.21.3/MANIFEST.in)
