### PR TITLE
fix test_UnbinnedNLL_visualize to use pytest.warns()

### DIFF
--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -237,7 +237,7 @@ def test_UnbinnedNLL_visualize(log):
     # manual spacing
     c.visualize((1, 2), model_points=np.linspace(1, 1000))
 
-    with pytest.raises(
+    with pytest.warns(
         np.VisibleDeprecationWarning, match="keyword 'nbins' is deprecated"
     ):
         c.visualize((1, 2), nbins=20)


### PR DESCRIPTION
Fix test_UnbinnedNLL_visualize to use pytest.warns() to check for the warning instead of pytest.raises().  This fixes the test failure when the test suite is run with -Wdefault, as is the case on Gentoo.