### PR TITLE
test_cost: use pytest.warns instead of raises for VisibleDeprecationWarning

### DIFF
--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -237,7 +237,7 @@ def test_UnbinnedNLL_visualize(log):
     # manual spacing
     c.visualize((1, 2), model_points=np.linspace(1, 1000))
 
-    with pytest.raises(
+    with pytest.warns(
         np.VisibleDeprecationWarning, match="keyword 'nbins' is deprecated"
     ):
         c.visualize((1, 2), nbins=20)


### PR DESCRIPTION
Fixes the following warning:
```
=============================== warnings summary ===============================
tests/test_cost.py::test_UnbinnedNLL_visualize[False]
tests/test_cost.py::test_UnbinnedNLL_visualize[True]
  /tmp/autopkgtest-lxc.hry0h8si/downtmp/autopkgtest_tmp/tests/test_cost.py:244: VisibleDeprecationWarning: keyword 'nbins' is deprecated, please use 'bins'
    c.visualize((1, 2), nbins=20)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====== 597 passed, 2 skipped, 5 xfailed, 1 xpassed, 2 warnings in 17.25s =======
```