### PR TITLE
fix safe_log on systems which use 32 bit floats

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -116,7 +116,7 @@ NEGATIVE_LOG_LIKELIHOOD = 0.5
 
 def _safe_log(x):
     # guard against x = 0
-    return np.log(x + 1e-323)
+    return np.log(np.maximum(np.finfo(x.dtype).smallest_normal, x))
 
 
 def _unbinned_nll(x):

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -113,10 +113,12 @@ __all__ = [
 CHISQUARE = 1.0
 NEGATIVE_LOG_LIKELIHOOD = 0.5
 
+_SMALLEST_NORMAL = np.finfo(float).smallest_normal
+
 
 def _safe_log(x):
     # guard against x = 0
-    return np.log(np.maximum(np.finfo(x.dtype).smallest_normal, x))
+    return np.log(np.maximum(_SMALLEST_NORMAL, x))
 
 
 def _unbinned_nll(x):

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1125,7 +1125,7 @@ def test_multinominal_chi2():
 
     assert multinominal_chi2(zero, zero) == 0
     assert multinominal_chi2(zero, one) == 0
-    assert multinominal_chi2(one, zero) == pytest.approx(1487, abs=1)
+    assert multinominal_chi2(one, zero) == pytest.approx(1416, abs=1)
     n = np.array([(0.0, 0.0)])
     assert_allclose(multinominal_chi2(n, zero), 0)
     assert_allclose(multinominal_chi2(n, one), 0)


### PR DESCRIPTION
Closes #913 see that issue for a detailed analysis by @stephanlachnit why the original naive code did not work everywhere.

Maybe this is related to #902, too.

@stephanlachnit Could you please check whether this fix indeed solves the issue? I cannot run tests on the affected systems.