### PR TITLE
fix CostSum.visualize bug

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -726,8 +726,10 @@ class CostSum(Cost, ABCSequence):
 
         n = sum(hasattr(comp, "visualize") for comp in self)
 
-        w, h = plt.rcParams["figure.figsize"]
-        fig, ax = plt.subplots(1, n, figsize=(w, h * n))
+        fig = plt.gcf()
+        w = fig.get_figwidth()
+        h = fig.get_figheight() * n / 1.5
+        _, ax = plt.subplots(1, n, figsize=(w, h), num=fig.number)
 
         if component_kwargs is None:
             component_kwargs = {}

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -727,9 +727,8 @@ class CostSum(Cost, ABCSequence):
         n = sum(hasattr(comp, "visualize") for comp in self)
 
         fig = plt.gcf()
-        w = fig.get_figwidth()
-        h = fig.get_figheight() * n / 1.5
-        _, ax = plt.subplots(1, n, figsize=(w, h), num=fig.number)
+        fig.set_figwidth(n * fig.get_figwidth() / 1.5)
+        _, ax = plt.subplots(1, n, num=fig.number)
 
         if component_kwargs is None:
             component_kwargs = {}


### PR DESCRIPTION
Fixes the bug that CostSum.visualize prints two figures and the wrong aspect ratio of the figure.