### PR TITLE
Support Interval type and check compatibility with pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ test = [
     "boost_histogram",
     "resample",
     "unicodeitplus",
+    "pydantic",
+    "annotated_types",
 ]
 doc = [
     "sphinx<7",

--- a/src/iminuit/typing.py
+++ b/src/iminuit/typing.py
@@ -71,3 +71,13 @@ class Le:
     """Annotation compatible with annotated-types."""
 
     le: float
+
+
+@dataclasses.dataclass
+class Interval:
+    """Annotation compatible with annotated-types."""
+
+    gt: Optional[float] = None
+    ge: Optional[float] = None
+    lt: Optional[float] = None
+    le: Optional[float] = None

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1276,15 +1276,22 @@ def _get_limit(annotation: Union[type, Annotated[float, Any], str]):
                 lim[0] = c.start
             if c.stop is not None:
                 lim[1] = c.stop
-        # Minuit does not distinguish between closed and open intervals
-        elif hasattr(c, "gt"):
-            lim[0] = c.gt
-        elif hasattr(c, "ge"):
-            lim[0] = c.ge
-        elif hasattr(c, "lt"):
-            lim[1] = c.lt
-        elif hasattr(c, "le"):
-            lim[1] = c.le
+        # Minuit does not distinguish between closed and open intervals.
+        # We use a chain of ifs so that the code also works with the
+        # `Interval` class, which contains several of those attributes
+        # and which can be None.
+        gt = getattr(c, "gt", None)
+        ge = getattr(c, "ge", None)
+        lt = getattr(c, "lt", None)
+        le = getattr(c, "le", None)
+        if gt is not None:
+            lim[0] = gt
+        if ge is not None:
+            lim[0] = ge
+        if lt is not None:
+            lim[1] = lt
+        if le is not None:
+            lim[1] = le
     return tuple(lim)
 
 


### PR DESCRIPTION
This adds support for the Interval annotation type that is in the package `annotated_types` and `pydantic`, which was previously missing. It also adds tests for float annotations from `annotated_types` and `pydantic`, to check that they are correctly handled by `util.describe`
