### PR TITLE
Clarify meaning of 2D contours in Minuit.draw_mnmatrix

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -27,11 +27,13 @@ These methods and properties you will probably use a lot:
     Minuit.fval
     Minuit.nfit
     Minuit.mnprofile
-    Minuit.draw_mnprofile
+    Minuit.mncontour
+    Minuit.visualize
+    Minuit.draw_mnmatrix
 
 
-Minuit
-------
+Main interface
+--------------
 
 .. autoclass:: Minuit
     :members:

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1916,7 +1916,11 @@ class Minuit:
         scan point. This scan produces a statistical confidence region according to the
         `profile likelihood method <https://en.wikipedia.org/wiki/Likelihood_function>`_
         with a confidence level `cl`, which is asymptotically equal to the coverage
-        probability of the confidence region.
+        probability of the confidence region according to `Wilks' theorem
+        <https://en.wikipedia.org/wiki/Wilks%27_theorem>`. Note that 1D projections of
+        the 2D confidence region are larger than 1D Minos intervals computed for the
+        same confidence level. This is not an error, but a consequence of Wilks'
+        theorem.
 
         The calculation is expensive since a numerical minimisation has to be performed
         at various points.
@@ -2087,12 +2091,9 @@ class Minuit:
         cells of the matrix show the 1D scan, the off-diagonal cells show 2D scans for
         all unique pairs of parameters.
 
-        The 2D contours should not be interpreted as having the requested confidence
-        level. The requested confidence level is valid only for the 1D interval. This
-        convention differs from other tools, because the matrix is a diagnostic tool. We
-        do not aim for a statistical interpretation of the 2D scans here based on Wilks'
-        theorem, rather the objective was here to align the 1D levels with the 2D
-        contours. To obtain a proper 2D contour with requested confidence level, use
+        The projected edges of the 2D contours do not align with the 1D intervals,
+        because of Wilks' theorem. The levels for 2D confidence regions are higher. For
+        more information on the interpretation of 2D confidence regions, see
         :meth:`mncontour`.
 
         Parameters

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2085,8 +2085,15 @@ class Minuit:
         This draws a matrix of Minos likelihood scans, meaning that the likelihood is
         minimized with respect to the parameters that are not scanned over. The diagonal
         cells of the matrix show the 1D scan, the off-diagonal cells show 2D scans for
-        all unique pairs of parameters. The 2D scans show confidence regions. See
-        :meth:`mncontour` for details on the interpretation of these regions.
+        all unique pairs of parameters.
+
+        The 2D contours should not be interpreted as having the requested confidence
+        level. The requested confidence level is valid only for the 1D interval. This
+        convention differs from other tools, because the matrix is a diagnostic tool. We
+        do not aim for a statistical interpretation of the 2D scans here based on Wilks'
+        theorem, rather the objective was here to align the 1D levels with the 2D
+        contours. To obtain a proper 2D contour with requested confidence level, use
+        :meth:`mncontour`.
 
         Parameters
         ----------


### PR DESCRIPTION
The method `Minuit.draw_mnmatrix` shows 2D contours that do not align with the 1D intervals, which is ok. The keyword `cl` sets the confidence level for the 1D intervals and 2D contours, according to Wilks' theorem, the projections of the 2D contours are then wider than the 1D intervals. The docstrings make this point more clear.
