### PR TITLE
Warn on errordef override

### DIFF
--- a/doc/notebooks/basic.ipynb
+++ b/doc/notebooks/basic.ipynb
@@ -648,7 +648,7 @@
                 "\n",
                 "If you like to understand the origin of these numbers, have a look into the study **Hesse and Minos**, which explains in depth how uncertainties are computed.\n",
                 "\n",
-                "For our custom cost function, we could set `m.errordef=1` or `m.errordef=Minuit.LEAST_SQUARES`, which is more readable. An even better way is to add an attribute called `errordef` to the cost function. If such an attribute is present, Minuit uses it. Since this cost function has the default scaling, we do not need to set anything, but keep it in mind for negative log-likelihoods."
+                "For our custom cost function, we could set `m.errordef=1` or `m.errordef=Minuit.LEAST_SQUARES`, which is more readable."
             ]
         },
         {
@@ -678,12 +678,56 @@
             ]
         },
         {
-            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
                 "The reported errors are now by a factor `sqrt(2)` smaller than they really are.\n",
                 "\n",
+                "An even better way is to add an attribute called `errordef` to the cost function. If such an attribute is present, Minuit uses it. Since this cost function has the default scaling, we do not need to set anything, but keep it in mind for negative log-likelihoods."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# artificial cost function that scales like a negative log-likelihood\n",
+                "def custom_least_squares_2(a, b):\n",
+                "    return 0.5 * custom_least_squares(a, b)\n",
+                "\n",
+                "# Instead of calling Minuit.errordef, we assign an errordef attribute to the cost\n",
+                "# function. Minuit will automatically use this value.\n",
+                "custom_least_squares_2.errordef = Minuit.LIKELIHOOD\n",
+                "\n",
+                "m = Minuit(custom_least_squares_2, 1, 2)\n",
+                "m.migrad()  # uses the correct errordef automatically"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "We get the correct errors. The built-in cost functions from the module `iminuit.cost` all define the `errordef` attribute, so you don't need to worry about that.\n",
+                "\n",
+                "If the cost function defines the `errordef`, it should not be necessary to set it to another value, so `Minuit` warns you if you try to set it."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# raises a warning\n",
+                "m.errordef = 1"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
                 "### Advanced: Initial step sizes\n",
                 "\n",
                 "Minuit uses a gradient-descent method to find the minimum, and the gradient is computed numerically using finite differences. The initial step size is used to compute the first gradient. A good step size is small compared to the curvature of the function, but large compared to numerical resolution. Using a good step size can slightly accelerate the convergence, but Minuit is not very sensitive to the choice. If you don't provide a value, iminuit will guess a step size based on a heuristic.\n",

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -5,6 +5,10 @@ We provide these for convenience, so that you do not have to write your own for 
 fits. The cost functions optionally use Numba to accelerate some calculations, if Numba
 is installed.
 
+**There is no need** to set :attr:`iminuit.Minuit.errordef` manually for any of these
+cost functions. :class:`iminuit.Minuit` automatically uses the correct value, which is
+provided by each cost function with the attribute ``Cost.errordef``.
+
 What to use when
 ----------------
 - Fit a normalised probability density to data

--- a/src/iminuit/warnings.py
+++ b/src/iminuit/warnings.py
@@ -13,5 +13,9 @@ class HesseFailedWarning(IMinuitWarning):
     """HESSE failed warning."""
 
 
+class ErrordefAlreadySetWarning(IMinuitWarning):
+    """The errordef attribute is already defined by the cost function."""
+
+
 class PerformanceWarning(UserWarning):
     """Warning about performance issues."""

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from iminuit import Minuit
 from iminuit.util import Param, make_func_code
-from iminuit.warnings import IMinuitWarning
+from iminuit.warnings import IMinuitWarning, ErrordefAlreadySetWarning
 from iminuit.typing import Annotated
 from pytest import approx
 from argparse import Namespace
@@ -1709,3 +1709,14 @@ def test_bad_grad():
 
     with pytest.raises(ValueError, match="provided gradient is not a CostGradient"):
         Minuit(cost, 0, 0, grad="foo")
+
+
+def test_errordef_already_set_warning():
+    def cost(a, b):
+        return a**2 + b**2
+
+    cost.errordef = 1
+
+    m = Minuit(cost, 0, 0)
+    with pytest.warns(ErrordefAlreadySetWarning):
+        m.errordef = 2


### PR DESCRIPTION
Closes #930 

- Documentation is added to the `iminuit.cost` module which explains that errordef should not be set manually when the builtin cost functions are used.
- Minuit now warns the user if Minuit.errordef is set if also the cost function has an errordef attribute, but the value set via Minuit.errordef still overrides the Cost.errordef attribute.