### PR TITLE
Fix strict return types in tests

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -236,7 +236,7 @@ class LimitView(BasicView):
         state.set_error(i, err)
 
 
-def _normalize_limit(lim: UserBound) -> Tuple[float, float]:
+def _normalize_limit(lim: Optional[Iterable]) -> Tuple[float, float]:
     if lim is None:
         return (-np.inf, np.inf)
     a, b = lim

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1164,7 +1164,7 @@ def test_CostSum_1(use_grad):
         return g
 
     def model3(x, c):
-        return c
+        return c * np.ones_like(x)
 
     def grad3(x, c):
         return np.ones((1, len(x)))

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1201,7 +1201,7 @@ def test_CostSum_1(use_grad):
         a = 2
         b = 3
         ref = np.zeros(2)
-        ref[0] += lsq1.grad(a)
+        ref[0] += lsq1.grad(a)[0]
         ref[[1, 0]] += lsq2.grad(b, a)
         assert_allclose(lsq12.grad(a, b), ref)
 
@@ -1214,9 +1214,9 @@ def test_CostSum_1(use_grad):
         a = 2
         b = 3
         ref = np.zeros(2)
-        ref[0] += lsq1.grad(a)
+        ref[0] += lsq1.grad(a)[0]
         ref[[1, 0]] += lsq2.grad(b, a)
-        ref[0] += lsq1.grad(a)
+        ref[0] += lsq1.grad(a)[0]
         assert_allclose(lsq121.grad(a, b), ref)
 
     lsq312 = lsq3 + lsq12
@@ -1229,8 +1229,8 @@ def test_CostSum_1(use_grad):
         b = 3
         c = 4
         ref = np.zeros(3)
-        ref[0] += lsq3.grad(c)
-        ref[1] += lsq1.grad(a)
+        ref[0] += lsq3.grad(c)[0]
+        ref[1] += lsq1.grad(a)[0]
         ref[[2, 1]] += lsq2.grad(b, a)
         assert_allclose(lsq312.grad(c, a, b), ref)
 

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -63,9 +63,9 @@ def test_tol():
 
 
 def test_disp(capsys):
-    minimize(lambda x: x**2, 0)
+    minimize(lambda x: np.sum(x**2), 0)
     assert capsys.readouterr()[0] == ""
-    minimize(lambda x: x**2, 0, options={"disp": True})
+    minimize(lambda x: np.sum(x**2), 0, options={"disp": True})
     assert capsys.readouterr()[0] != ""
 
 
@@ -115,7 +115,7 @@ def test_bad_function():
 
         def __call__(self, x):
             self.n += 1
-            return x**2 + 1e-2 * (self.n % 3)
+            return np.sum(x**2 + 1e-2 * (self.n % 3))
 
     r = minimize(Fcn(), [1], options={"maxfun": 100000000})
     assert not r.success


### PR DESCRIPTION
This fixes the failing tests and two performance warnings raised in the tests. Like @henryiii suggested, these changes were needed in one particular test which relied on broadcasting rules that have been removed from numpy.