### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/bench/plot.ipynb
+++ b/bench/plot.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "code",
    "execution_count": 9,


### PR DESCRIPTION
Reduces dependabot spam, and actually helps with linked actions (like upload/download artifact v4 not being compatible with v3).

See https://github.com/scientific-python/cookie/pull/348.
