### PR TITLE
check for odr violations and fix odr violation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,16 @@ if(MSVC)
   target_compile_options(_core PRIVATE /std:c++14 /Y-)
 else()
   # lots of warnings from clang and gcc
-  target_compile_options(_core PRIVATE -Wall -Wextra -pedantic -Werror
-                                       -fstrict-aliasing)
+  target_compile_options(
+    _core
+    PRIVATE -Wall
+            -Wextra
+            -pedantic
+            -Werror
+            -fstrict-aliasing
+            -Werror=odr
+            -Werror=selector-type-mismatch
+            -Werror=strict-aliasing)
 endif()
 target_include_directories(_core PRIVATE extern/root/math/minuit2/inc)
 set_target_properties(_core PROPERTIES VISIBILITY_INLINES_HIDDEN ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ set(SOURCES_B
 pybind11_add_module(_core MODULE ${SOURCES_A} ${SOURCES_B})
 if(MSVC)
   target_compile_options(_core PRIVATE /std:c++14 /Y-)
-else()
-  # lots of warnings from clang and gcc
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  # lots of warnings from gcc, including odr violations
   target_compile_options(
     _core
     PRIVATE -Wall
@@ -95,8 +95,12 @@ else()
             -Werror
             -fstrict-aliasing
             -Werror=odr
-            -Werror=selector-type-mismatch
+            -Werror=lto-type-mismatch
             -Werror=strict-aliasing)
+else()
+  # lots of warnings from clang
+  target_compile_options(_core PRIVATE -Wall -Wextra -pedantic -Werror
+                                       -fstrict-aliasing)
 endif()
 target_include_directories(_core PRIVATE extern/root/math/minuit2/inc)
 set_target_properties(_core PROPERTIES VISIBILITY_INLINES_HIDDEN ON)

--- a/src/type_caster.hpp
+++ b/src/type_caster.hpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <vector>
@@ -6,9 +5,9 @@
 namespace pybind11 {
 namespace detail {
 
-template <typename Value>
-struct type_caster<std::vector<Value>> {
-  using vec_t = std::vector<Value>;
+template <typename Value, typename Alloc>
+struct type_caster<std::vector<Value, Alloc>> {
+  using vec_t = std::vector<Value, Alloc>;
   using value_conv = make_caster<Value>;
   using size_conv = make_caster<std::size_t>;
 


### PR DESCRIPTION
Closes #976 

This fixes an ODR violation and adds more warnings regarding ODR violations to the standard build flags (which are treated as errors).