### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - os: windows-latest
             python-version: "3.11"
             installs: "numpy>=2.0.0rc1"
-          - os: macos-13
+          - os: macos-14
             python-version: "3.8"
             installs: "'numpy==1.21.0'"
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - os: windows-latest
             python-version: "3.11"
             installs: "numpy>=2.0.0rc1"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.8"
             installs: "'numpy==1.21.0'"
           - os: ubuntu-latest

--- a/doc/notebooks/correlated_data.ipynb
+++ b/doc/notebooks/correlated_data.ipynb
@@ -1,5 +1,5 @@
 {
- "cells": [
+  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

GitHub is doing a staged rollout of `macos-latest` pointing at `macos-14`, which is an ARM based runner and only supports Python 3.10+. This locks in the Intel runner (until GitHub eventually removes them).

Edit: GitHub has just shipped macos ARM Python 3.8 & 3.9, so when the staged rollout hits this repo, it might still working. I'll try explicitly using the new runners to test.