### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,10 @@ jobs:
   upload:
     needs: [wheels, sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/download-artifact@v4
@@ -96,6 +100,11 @@ jobs:
           pattern: "*"
           merge-multiple: true
           path: dist
+
+      - name: Generate artifact attestation for sdist and wheels
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/iminuit-*"
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
     pass_filenames: false
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.3
+  rev: 0.28.4
   hooks:
   - id: check-readthedocs
   - id: check-github-workflows


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload.
  c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Update `python-jsonschema/check-jsonschema` pre-commit hook to recognize `attestations` `permissions` key.