### PR TITLE
fix for VisibleDeprecationWarning, useful annotated types, support tuple annotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ log_cli_level = "INFO"
 testpaths = ["tests"]
 xfail_strict = true
 filterwarnings = [
-    "error::iminuit._exceptions.VisibleDeprecationWarning",
     "error::PendingDeprecationWarning",
     "error::DeprecationWarning",
     "error::FutureWarning",

--- a/src/iminuit/_deprecated.py
+++ b/src/iminuit/_deprecated.py
@@ -1,36 +1,45 @@
 import warnings
-from ._exceptions import VisibleDeprecationWarning
+from packaging.version import Version
+from typing import Callable, Any
+from importlib.metadata import version
+
+CURRENT_VERSION = Version(version("sweights"))
 
 
 class deprecated:
-    def __init__(self, reason):
-        self._reason = reason
+    def __init__(self, reason: str, removal: str = ""):
+        self.reason = reason
+        self.removal = Version(removal) if removal else None
 
-    def __call__(self, func):
-        def decorated_func(*args, **kwargs):
-            warnings.warn(
-                f"{func.__name__} is deprecated: {self._reason}",
-                category=VisibleDeprecationWarning,
-                stacklevel=2,
-            )
+    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        category: Any = FutureWarning
+        extra = ""
+        if self.removal:
+            extra = f" and will be removed in version {self.removal}"
+            if CURRENT_VERSION >= self.removal:
+                category = DeprecationWarning
+        msg = f"{func.__name__} is deprecated{extra}: {self.reason}"
+
+        def decorated_func(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(msg, category=category, stacklevel=2)
             return func(*args, **kwargs)
 
         decorated_func.__name__ = func.__name__
-        decorated_func.__doc__ = "deprecated: " + self._reason
+        decorated_func.__doc__ = msg
         return decorated_func
 
 
 class deprecated_parameter:
-    def __init__(self, **replacements):
-        self._replacements = replacements
+    def __init__(self, **replacements: str):
+        self.replacements = replacements
 
-    def __call__(self, func):
-        def decorated_func(*args, **kwargs):
-            for new, old in self._replacements.items():
+    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        def decorated_func(*args: Any, **kwargs: Any) -> Any:
+            for new, old in self.replacements.items():
                 if old in kwargs:
                     warnings.warn(
                         f"keyword {old!r} is deprecated, please use {new!r}",
-                        category=VisibleDeprecationWarning,
+                        category=FutureWarning,
                         stacklevel=2,
                     )
                     kwargs[new] = kwargs[old]

--- a/src/iminuit/_deprecated.py
+++ b/src/iminuit/_deprecated.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 from typing import Callable, Any
 from importlib.metadata import version
 
-CURRENT_VERSION = Version(version("sweights"))
+CURRENT_VERSION = Version(version("iminuit"))
 
 
 class deprecated:

--- a/src/iminuit/_exceptions.py
+++ b/src/iminuit/_exceptions.py
@@ -1,7 +1,0 @@
-# NumPy 2 and recent 1.x place this in exceptions
-try:
-    from numpy.exceptions import VisibleDeprecationWarning
-except ImportError:
-    from numpy import VisibleDeprecationWarning
-
-__all__ = ["VisibleDeprecationWarning"]

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -92,7 +92,6 @@ from .util import (
     is_positive_definite,
 )
 from .typing import Model, ModelGradient, LossFunction
-from ._exceptions import VisibleDeprecationWarning
 import numpy as np
 from numpy.typing import NDArray, ArrayLike
 from collections.abc import Sequence as ABCSequence
@@ -1758,7 +1757,7 @@ class Template(BinnedCost):
         if method == "hpd":
             warnings.warn(
                 "key 'hpd' is deprecated, please use 'da' instead",
-                category=VisibleDeprecationWarning,
+                category=FutureWarning,
                 stacklevel=2,
             )
 
@@ -2512,7 +2511,7 @@ def __getattr__(name: str) -> Any:
         new_name, obj = _deprecated_content[name]
         warnings.warn(
             f"{name} was renamed to {new_name}, please import {new_name} instead",
-            VisibleDeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         return obj

--- a/src/iminuit/typing.py
+++ b/src/iminuit/typing.py
@@ -108,3 +108,8 @@ class Interval:
     ge: Optional[float] = None
     lt: Optional[float] = None
     le: Optional[float] = None
+
+
+# common convenience types
+PositiveFloat = Annotated[float, Gt(0)]
+Probability = Annotated[float, Interval(ge=0, le=1)]

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -18,7 +18,6 @@ from iminuit.cost import (
 )
 from iminuit.util import describe
 from iminuit.typing import Annotated, Gt, Lt
-from iminuit._exceptions import VisibleDeprecationWarning
 from typing import Sequence
 import pickle
 
@@ -321,7 +320,7 @@ def test_UnbinnedNLL_visualize(log):
     # manual spacing
     c.visualize((1, 2), model_points=np.linspace(1, 1000))
 
-    with pytest.warns(VisibleDeprecationWarning, match="keyword 'nbins' is deprecated"):
+    with pytest.warns(FutureWarning, match="keyword 'nbins' is deprecated"):
         c.visualize((1, 2), nbins=20)
 
 
@@ -1908,15 +1907,15 @@ def test_Template_pulls():
 def test_deprecated():
     from iminuit import cost
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         from iminuit.cost import BarlowBeestonLite
     assert BarlowBeestonLite is cost.Template
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         from iminuit.cost import barlow_beeston_lite_chi2_jsc
     assert barlow_beeston_lite_chi2_jsc is cost.template_chi2_jsc
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         from iminuit.cost import barlow_beeston_lite_chi2_hpd
     assert barlow_beeston_lite_chi2_hpd is cost.template_chi2_da
 
@@ -1924,7 +1923,7 @@ def test_deprecated():
 def test_deprecated_Template_method():
     from iminuit import cost
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         t = Template([1], [2, 3], [[1], [2]], method="hpd")
         t._impl is cost.template_chi2_da
 
@@ -1966,7 +1965,7 @@ def test_binned_cost_with_model_shape_error_message_2D(cost):
 def test_BohmZechTransform():
     from iminuit.cost import BohmZechTransform
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         val = np.array([1.0, 2.0])
         var = np.array([3.0, 4.0])
         tr = BohmZechTransform(val, var)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,14 +1,28 @@
 from iminuit._deprecated import deprecated, deprecated_parameter
-from iminuit._exceptions import VisibleDeprecationWarning
 import pytest
 
 
-def test_deprecated_func():
+def test_deprecated_func_1():
     @deprecated("bla")
     def func(x):
         pass
 
-    with pytest.warns(VisibleDeprecationWarning, match="func is deprecated: bla"):
+    with pytest.warns(
+        FutureWarning,
+        match="func is deprecated: bla",
+    ):
+        func(1)
+
+
+def test_deprecated_func_2():
+    @deprecated("bla", removal="1.0")
+    def func(x):
+        pass
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="func is deprecated and will be removed in version 1.0: bla",
+    ):
         func(1)
 
 
@@ -20,7 +34,7 @@ def test_deprecated_parameter():
     some_function(1, 2, foo=3)
 
     with pytest.warns(
-        VisibleDeprecationWarning,
+        FutureWarning,
         match="keyword 'bar' is deprecated, please use 'foo'",
     ):
         some_function(1, 2, bar=3)

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1,6 +1,5 @@
 from iminuit.util import describe, make_func_code
 from iminuit.typing import Annotated, Gt, Lt, Ge, Le, Interval
-from iminuit._exceptions import VisibleDeprecationWarning
 from math import ldexp
 import platform
 from functools import wraps
@@ -95,7 +94,7 @@ def test_generic_functor_with_fake_func():
         def __call__(self, *args):
             pass
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         assert describe(A()) == ["x", "y"]
 
 

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -201,6 +201,7 @@ def test_with_type_hints():
         d: Annotated[float, Ge(1)],
         e: Annotated[float, Le(2)],
         f: Annotated[float, Interval(gt=2, lt=3)],
+        g: Annotated[float, (4, 5)],
     ): ...
 
     r = describe(foo, annotations=True)
@@ -212,6 +213,7 @@ def test_with_type_hints():
         "d": (1, np.inf),
         "e": (-np.inf, 2),
         "f": (2, 3),
+        "g": (4, 5),
     }
 
     class Foo:

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -6,7 +6,6 @@ from iminuit import Minuit
 from iminuit.util import Param, make_func_code
 from iminuit.warnings import IMinuitWarning, ErrordefAlreadySetWarning
 from iminuit.typing import Annotated
-from iminuit._exceptions import VisibleDeprecationWarning
 from pytest import approx
 from argparse import Namespace
 
@@ -194,7 +193,7 @@ def test_Func1():
 
 
 def test_Func2():
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         func_test_helper(Func2())
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,6 @@ from iminuit._core import MnUserParameterState
 from iminuit._optional_dependencies import optional_module_for
 import pickle
 from iminuit._hide_modules import hide_modules
-from iminuit._exceptions import VisibleDeprecationWarning
 
 try:
     import scipy  # noqa
@@ -451,12 +450,12 @@ def test_address_of_cfunc_bad_signature():
 
 
 def test_make_func_code():
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         fc = util.make_func_code(["a", "b"])
     assert fc.co_varnames == ("a", "b")
     assert fc.co_argcount == 2
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         fc = util.make_func_code(("x",))
     assert fc.co_varnames == ("x",)
     assert fc.co_argcount == 1
@@ -531,14 +530,14 @@ def test_propagate_1():
     def fn(x):
         return 2 * x + 1
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_allclose(y, [3, 5, 7])
     np.testing.assert_allclose(
         ycov, [[4, 0.4, 0.8], [0.4, 8, 1.2], [0.8, 1.2, 12]], rtol=1e-3
     )
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         y, ycov = util.propagate(fn, [1], [[2]])
     np.testing.assert_allclose(y, 3)
     np.testing.assert_allclose(ycov, 8, rtol=1e-3)
@@ -558,7 +557,7 @@ def test_propagate_2():
     def fn(x):
         return np.dot(a, x)
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_equal(y, fn(x))
     np.testing.assert_allclose(ycov, np.einsum("ij,kl,jl", a, a, cov), rtol=1e-3)
@@ -566,7 +565,7 @@ def test_propagate_2():
     def fn(x):
         return np.linalg.multi_dot([x.T, cov, x])
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_equal(y, fn(np.array(x)))
     jac = 2 * np.dot(cov, x)
@@ -586,7 +585,7 @@ def test_propagate_3():
     def fn(x):
         return 2 * x + 1
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         y, ycov = util.propagate(fn, x, cov)
     np.testing.assert_allclose(y, [3, 5, 7])
     np.testing.assert_allclose(ycov, [[4, 0.0, 0.8], [0.0, 0.0, 0.0], [0.8, 0.0, 12]])
@@ -600,16 +599,16 @@ def test_propagate_on_bad_input():
     def fn(x):
         return 2 * x + 1
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             util.propagate(fn, x, cov)
 
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             util.propagate(fn, x, 1)
 
     cov = [[1.0], [1.0]]
-    with pytest.warns(VisibleDeprecationWarning):
+    with pytest.warns(FutureWarning):
         with pytest.raises(ValueError):
             util.propagate(fn, x, cov)
 


### PR DESCRIPTION
- `describe` now also recognizes `Annotated[float, (a, b)]` as the limit (a, b) for the parameter.
- added convenience types: PositiveFloat, Probability under iminuit.typing
- Replaced VisibibleDeprecationWarning with FutureWarning
- Upgraded _deprecated