### PR TITLE
Add name argument to all cost functions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -59,7 +59,7 @@ def pypy(session: nox.Session) -> None:
 
 
 # Python-3.12 provides coverage info faster
-@nox.session(python="3.12", venv_backend="uv")
+@nox.session(python="3.12", venv_backend="uv", reuse_venv=True)
 def cov(session: nox.Session) -> None:
     """Run covage and place in 'htmlcov' directory."""
     session.install("-e.[test,doc]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,7 +29,8 @@ nox.options.sessions = ["test", "mintest", "maxtest"]
 def test(session: nox.Session) -> None:
     """Run all tests."""
     session.install("-e.[test]")
-    session.run("pytest", "-n=auto", *session.posargs, env=ENV)
+    extra_args = session.posargs if session.posargs else ("-n=auto",)
+    session.run("pytest", *extra_args, env=ENV)
 
 
 @nox.session(python=MINIMUM_PYTHON, venv_backend="uv")
@@ -37,14 +38,16 @@ def mintest(session: nox.Session) -> None:
     """Run tests on the minimum python version."""
     session.install("-e.", "--resolution=lowest-direct")
     session.install("pytest", "pytest-xdist")
-    session.run("pytest", "-n=auto", *session.posargs)
+    extra_args = session.posargs if session.posargs else ("-n=auto",)
+    session.run("pytest", *extra_args)
 
 
 @nox.session(python=LATEST_PYTHON)
 def maxtest(session: nox.Session) -> None:
     """Run the unit and regular tests."""
     session.install("-e.", "scipy", "matplotlib", "pytest", "pytest-xdist", "--pre")
-    session.run("pytest", "-n=auto", *session.posargs, env=ENV)
+    extra_args = session.posargs if session.posargs else ("-n=auto",)
+    session.run("pytest", *extra_args, env=ENV)
 
 
 @nox.session(python="pypy3.9")

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ LATEST_PYTHON = str(python_releases.latest())
 nox.options.sessions = ["test", "mintest", "maxtest"]
 
 
-@nox.session()
+@nox.session(reuse_venv=True)
 def test(session: nox.Session) -> None:
     """Run all tests."""
     session.install("-e.[test]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "numpy >=1.21",
-    "typing_extensions >=3.7.4; python_version<'3.9'",
-]
+dependencies = ["numpy >=1.21"]
 
 [project.urls]
 repository = "http://github.com/scikit-hep/iminuit"

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -2545,7 +2545,8 @@ def _model_parameters(model, name):
             params = {n: att for (n, att) in zip(name, params.values())}
         elif len(params) > 0:
             raise ValueError("length of name does not match number of model parameters")
-        params = {n: None for n in name}
+        else:
+            params = {n: None for n in name}
     return params
 
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -589,6 +589,19 @@ def test_BinnedNLL_weighted(use_grad):
         assert m2.ngrad == 0
 
 
+def test_BinnedNLL_name(binned):
+    mle, nx, xe = binned
+
+    cost = BinnedNLL(nx, xe, lambda x, *par: cdf(x, *par), name=("mu", "sigma"))
+    assert cost.ndata == len(nx)
+
+    m = Minuit(cost, mu=0, sigma=1)
+    m.limits["sigma"] = (0, None)
+    m.migrad()
+    assert m.valid
+    assert m.parameters == ("mu", "sigma")
+
+
 def test_BinnedNLL_bad_input_1():
     with pytest.raises(ValueError):
         BinnedNLL([1], [1], lambda x, a: 0)
@@ -842,6 +855,21 @@ def test_ExtendedBinnedNLL(binned, verbose, use_grad):
         assert m.ngrad > 0
     else:
         assert m.ngrad == 0
+
+
+def test_ExtendedBinnedNLL_name(binned):
+    mle, nx, xe = binned
+
+    cost = ExtendedBinnedNLL(
+        nx, xe, lambda x, *par: scaled_cdf(x, *par), name=("n", "mu", "sigma")
+    )
+    assert cost.ndata == len(nx)
+
+    m = Minuit(cost, n=mle[0], mu=0, sigma=1)
+    m.limits["sigma"] = (0, None)
+    m.migrad()
+    assert m.valid
+    assert m.parameters == ("n", "mu", "sigma")
 
 
 @pytest.mark.parametrize("use_grad", (False, True))

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -99,16 +99,32 @@ def pdf(x, mu, sigma):
     return norm_pdf(x, mu, sigma)
 
 
+def pdf_nosig(x, *par):
+    return norm_pdf(x, *par)
+
+
 def cdf(x, mu, sigma):
     return norm_cdf(x, mu, sigma)
+
+
+def cdf_nosig(x, *par):
+    return norm_cdf(x, *par)
 
 
 def scaled_cdf(x, n, mu, sigma):
     return n * norm_cdf(x, mu, sigma)
 
 
+def scaled_cdf_nosig(x, *par):
+    return par[0] * norm_cdf(x, *par[1:])
+
+
 def line(x, a, b):
     return a + b * x
+
+
+def line_nosig(x, *par):
+    return par[0] + par[1] * x
 
 
 def test_norm_logpdf():
@@ -228,6 +244,19 @@ def test_UnbinnedNLL(unbinned, verbose, model, use_grad):
         rho1 = m.covariance.correlation()[0, 1]
         rho2 = cov[0, 1] / (cov[0, 0] * cov[1, 1]) ** 0.5
         assert_allclose(rho1, rho2, atol=0.01)
+
+
+def test_UnbinnedNLL_name(unbinned):
+    mle, x = unbinned
+
+    cost = UnbinnedNLL(x, pdf_nosig, name=("mu", "sigma"))
+    assert cost.ndata == np.inf
+
+    m = Minuit(cost, mu=0, sigma=1)
+    assert m.parameters == ("mu", "sigma")
+    m.limits["sigma"] = (0, None)
+    m.migrad()
+    assert m.valid
 
 
 @pytest.mark.parametrize("use_grad", (False, True))
@@ -396,6 +425,22 @@ def test_ExtendedUnbinnedNLL(unbinned, verbose, model, use_grad):
         assert m.ngrad > 0
     else:
         assert m.ngrad == 0
+
+
+def test_ExtendedUnbinnedNLL_name(unbinned):
+    mle, x = unbinned
+
+    cost = ExtendedUnbinnedNLL(
+        x, lambda x, *par: (par[0], pdf(x, *par[1:])), name=("n", "mu", "sigma")
+    )
+    assert cost.ndata == np.inf
+
+    m = Minuit(cost, n=len(x), mu=0, sigma=1)
+    assert m.parameters == ("n", "mu", "sigma")
+    m.limits["n"] = (0, None)
+    m.limits["sigma"] = (0, None)
+    m.migrad()
+    assert m.valid
 
 
 @pytest.mark.parametrize("use_grad", (False, True))
@@ -592,7 +637,7 @@ def test_BinnedNLL_weighted(use_grad):
 def test_BinnedNLL_name(binned):
     mle, nx, xe = binned
 
-    cost = BinnedNLL(nx, xe, lambda x, *par: cdf(x, *par), name=("mu", "sigma"))
+    cost = BinnedNLL(nx, xe, cdf_nosig, name=("mu", "sigma"))
     assert cost.ndata == len(nx)
 
     m = Minuit(cost, mu=0, sigma=1)
@@ -860,9 +905,7 @@ def test_ExtendedBinnedNLL(binned, verbose, use_grad):
 def test_ExtendedBinnedNLL_name(binned):
     mle, nx, xe = binned
 
-    cost = ExtendedBinnedNLL(
-        nx, xe, lambda x, *par: scaled_cdf(x, *par), name=("n", "mu", "sigma")
-    )
+    cost = ExtendedBinnedNLL(nx, xe, scaled_cdf_nosig, name=("n", "mu", "sigma"))
     assert cost.ndata == len(nx)
 
     m = Minuit(cost, n=mle[0], mu=0, sigma=1)
@@ -1056,17 +1099,14 @@ def test_LeastSquares(loss, verbose, use_grad):
     ye = 0.1
     y = rng.normal(2 * x + 1, ye)
 
-    def model(x, a, b):
-        return a + b * x
-
     cost = LeastSquares(
         x,
         y,
         ye,
-        model,
+        line,
         loss=loss,
         verbose=verbose,
-        grad=numerical_model_gradient(model),
+        grad=numerical_model_gradient(line),
     )
     assert cost.ndata == len(x)
 
@@ -1091,6 +1131,22 @@ def test_LeastSquares(loss, verbose, use_grad):
         assert m.ngrad > 0
     else:
         assert m.ngrad == 0
+
+
+def test_LeastSquares_name():
+    rng = np.random.default_rng(1)
+
+    x = np.linspace(0, 1, 1000)
+    ye = 0.1
+    y = rng.normal(2 * x + 1, ye)
+
+    cost = LeastSquares(x, y, ye, line_nosig, name=("a", "b"))
+    assert cost.ndata == len(x)
+
+    m = Minuit(cost, a=0, b=0)
+    assert m.parameters == ("a", "b")
+    m.migrad()
+    assert_allclose(m.values, (1, 2), rtol=0.05)
 
 
 def test_LeastSquares_2D():


### PR DESCRIPTION
Closes #941 

So far the iminuit.cost functions only support models that pass each parameter as a positional argument. This makes it difficult to use models whose number of arguments should be easy to vary.

To make working with the latter easier, the cost functions now support models with a variable number of arguments in the form `def model(x, *par)`. The actual number of arguments and their names are then passed with the new keyword `name`, which can also be used to override the model parameter names found by inspecting the model signature.

- [x] Template
- [x] BinnedNLL
- [x] ExtendedBinnedNLL
- [x] LeastSquares
- [x] UnbinnedNLL
- [x] ExtendedUnbinnedNLL