### PR TITLE
Set `PYBIND11_FINDPYTHON` `ON` to use `FindPython` CMake mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_CXX_STANDARD
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # optional, ensure standard is supported
 set(CMAKE_CXX_EXTENSIONS OFF) # optional, keep compiler extensionsn off
 
+set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
 file(GLOB SOURCES_A "src/*.cpp")


### PR DESCRIPTION
## Description

This is a small PR to configure the CMake 3.18+ `FindPython` mode for `pybind11` to let it use the CMake search methods, in order to avoid having to pass the older `Python_ROOT_DIR`/`Python_INCLUDE_DIR` methods.

I'm not sure if anything else needs to be configured further – the selected `nox` sessions all pass on my machine locally and the recipe builds successfully within a Pyodide Docker container with this patch applied.

## Additional context

- This came up in https://github.com/pyodide/pyodide/pull/4767
- See also: https://github.com/pyodide/pyodide/discussions/2186