### PR TITLE
fix: missing dependency on packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dependencies = ["numpy >=1.21"]
+dependencies = ["packaging", "numpy >=1.21"]
 
 [project.urls]
 repository = "http://github.com/scikit-hep/iminuit"


### PR DESCRIPTION
This is used, but not declared. So many packages depend on this that it's being always pulled in for testing, but in a minimal environment it's missing.

See https://github.com/pyodide/pyodide/pull/4767#issuecomment-2291397326.