### PR TITLE
ci: add 3.13 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - if: ${{ github.ref == 'refs/heads/main' }}
         run: |
@@ -44,7 +44,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         arch: [auto, aarch64]
-        py: [cp39, cp310, cp311, cp312]
+        py: [cp39, cp310, cp311, cp312, cp313]
         exclude:
           - os: windows-latest
             arch: aarch64
@@ -63,7 +63,7 @@ jobs:
 
       - uses: yezz123/setup-uv@v4
 
-      - uses: pypa/cibuildwheel@v2.20
+      - uses: pypa/cibuildwheel@v2.21
         env:
           CIBW_BUILD: ${{ matrix.py }}-*
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -103,7 +103,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: read
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,15 @@ jobs:
           # version number must be string, otherwise 3.10 becomes 3.1
           - os: windows-latest
             python-version: "3.11"
-            installs: "numpy>=2.0.0rc1"
+            installs: "numpy>=2"
           - os: macos-14
             python-version: "3.9"
             installs: "numpy==1.21.0 scipy matplotlib"
           - os: ubuntu-latest
             python-version: "pypy-3.9"
           - os: ubuntu-latest
-            python-version: "3.12"
-            installs: "'numpy>=2.0.0rc1' scipy matplotlib"
+            python-version: "3.13"
+            installs: "'numpy>=2' scipy matplotlib"
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -46,6 +46,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     # pip install .[test] is not used here to test minimum (faster)
     # cov workflow runs all tests
     - run: uv pip install --system . pytest pytest-xdist ${{ matrix.installs }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ no_implicit_optional = false
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
+skip = ["cp39-musllinux_i686"] # no numpy wheel
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 test-skip = ["*universal2:arm64"]
@@ -135,7 +136,7 @@ PIP_ONLY_BINARY = ":all:"
 
 [[tool.cibuildwheel.overrides]]
 # to match numpy, we use manylinux2010 for cp36 to cp39
-select = "cp3?-*"
+select = "cp3?-manylinux*"
 manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
 build-frontend = "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,14 +121,13 @@ no_implicit_optional = false
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-# update skip when numpy wheels become available
-skip = ["*-musllinux_*", "cp31?-manylinux_i686"]
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 test-skip = ["*universal2:arm64"]
 # to match numpy, we use manylinux2014 for cp310+
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
+free-threaded-support = true
 
 [tool.cibuildwheel.environment]
 # this makes sure that we build only on platforms that have a corresponding numpy wheel

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ void bind_usercovariance(py::module);
 void bind_userparameterstate(py::module);
 void bind_usertransformation(py::module);
 
-PYBIND11_MODULE(_core, m) {
+PYBIND11_MODULE(_core, m, py::mod_gil_not_used()) {
   bind_application(m);
   bind_contours(m);
   bind_fcn(m);


### PR DESCRIPTION
Adding 3.13 wheels. ~~Doesn't add free-threaded wheels yet.~~ Remove outdated skips for NumPy.

Close #1044.