### PR TITLE
ci: use official GHA for uv

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - uses: yezz123/setup-uv@v4
+    - uses: astral-sh/setup-uv@v3
     - run: uv pip install --system nox
     - run: nox -s cov
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         python-version: "3.11"
     - run: sudo apt-get install pandoc
-    - uses: yezz123/setup-uv@v4
+    - uses: astral-sh/setup-uv@v3
     - run: uv pip install --system nox
     - run: nox -s doc
     - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - if: ${{ matrix.arch == 'aarch64' }}
         uses: docker/setup-qemu-action@v3
 
-      - uses: yezz123/setup-uv@v4
+      - uses: astral-sh/setup-uv@v3
 
       - uses: pypa/cibuildwheel@v2.20
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.python-version }}
     - uses: rui314/setup-mold@v1
       if: runner.os == 'Linux'
-    - uses: yezz123/setup-uv@v4
+    - uses: astral-sh/setup-uv@v3
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This exists now, and doesn't produce a notice on each job warning about "latest".
