### PR TITLE
fix: use old license text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "2.30.1"
 maintainers = [{ name = "Hans Dembinski", email = "hans.dembinski@gmail.com" }]
 readme = "README.rst"
 requires-python = ">=3.9"
-license = { file = "LICENSE" }
+license = { text = "MIT+LGPL" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Before moving to scikit-build-core, this was the contents of the `License` field. Putting the entire contents of the license file here breaks `importlib.metadata.metadata("iminuit")` (see https://github.com/python/cpython/issues/119650), and isn't needed - the license file is stored in the wheel already, and the currently only canonical location for license metadata is the trove classifiers. PEP 639, which is currently provisionally accepted and waiting support in packaging, PyPI, etc, solves this by supporting SPDX license expressions. But that's not ready yet.

(This is not critical, but a minor annoyance I hit while debugging)