### PR TITLE
Add ability to pass options to SciPy minimizers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
 
 # Ruff linter and formatter
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.6.9'
+  rev: 'v0.7.0'
   hooks:
     - id: ruff
       args: [--fix, --show-fixes]
@@ -42,7 +42,7 @@ repos:
 
 # C++ formatting
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.1
+  rev: v19.1.2
   hooks:
   - id: clang-format
     files: "src"
@@ -58,7 +58,7 @@ repos:
 
 # Python type checking
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.11.2'
+  rev: 'v1.12.1'
   hooks:
   - id: mypy
     additional_dependencies: [numpy]
@@ -73,11 +73,11 @@ repos:
     args: [--drop-empty-cells]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.3
+  rev: 0.29.4
   hooks:
   - id: check-github-workflows
 
 - repo: https://github.com/henryiii/validate-pyproject-schema-store
-  rev: 2024.09.23
+  rev: 2024.10.14
   hooks:
   - id: validate-pyproject

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -987,7 +987,7 @@ class Minuit:
         hess: Any = None,
         hessp: Any = None,
         constraints: Iterable = None,
-        options: Dict[str, ...] = {},
+        options: Dict[str, Any] = {},
     ) -> "Minuit":
         """
         Minimize with SciPy algorithms.

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1034,10 +1034,10 @@ class Minuit:
         the tolerance :attr:`tol` has no effect on SciPy minimizers.
 
         You can specify convergence tolerance and other options for the SciPy minimizers
-        through the `options` parameter. Note that providing the SciPy options 
-        `"maxiter"`, `"maxfev"`, and/or `"maxfun"` (depending on the minimizer) takes 
-        precedence over providing a value for `ncall`. If you want to explicitly control 
-        the number of iterations or function evaluations for a particular SciPy minimizer, 
+        through the `options` parameter. Note that providing the SciPy options
+        `"maxiter"`, `"maxfev"`, and/or `"maxfun"` (depending on the minimizer) takes
+        precedence over providing a value for `ncall`. If you want to explicitly control
+        the number of iterations or function evaluations for a particular SciPy minimizer,
         you should provide values for all of its relevant options.
         """
         try:

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1033,7 +1033,7 @@ class Minuit:
         means that usually SciPy minimizers will use more iterations than Migrad and
         the tolerance :attr:`tol` has no effect on SciPy minimizers.
 
-        You can specify convergance tolerance and other options for the SciPy minimizers
+        You can specify convergence tolerance and other options for the SciPy minimizers
         through the `options` parameter.
         """
         try:

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1239,8 +1239,7 @@ class Minuit:
         scipy_options = dict(options)
 
         # attempt to set default number of function evaluations if not provided
-        # if both "maxiter" and "maxfev" / "maxfun" are provided, minimization
-        # will stop at the first reached
+        # various workarounds for API inconsistencies in scipy.optimize.minimize
         if "maxiter" not in options:
             scipy_options["maxiter"] = ncall
         if method in (
@@ -1249,12 +1248,15 @@ class Minuit:
         ):
             if "maxfev" not in options:
                 scipy_options["maxfev"] = ncall
+            
+            if "maxiter" not in options:
+                del scipy_options["maxiter"]
 
         if method in ("L-BFGS-B", "TNC"):
             if "maxfun" not in options:
                 scipy_options["maxfun"] = ncall
-            
-            if method == "TNC":
+
+            if "maxiter" not in options:
                 del scipy_options["maxiter"]
 
         if method in ("COBYLA", "SLSQP", "trust-constr") and constraints is None:

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1235,8 +1235,7 @@ class Minuit:
             else:
                 method = "BFGS"
 
-        # copy to avoid mutable problems
-        scipy_options = dict(options)
+        options = options or {}
 
         # attempt to set default number of function evaluations if not provided
         # various workarounds for API inconsistencies in scipy.optimize.minimize

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -987,7 +987,7 @@ class Minuit:
         hess: Any = None,
         hessp: Any = None,
         constraints: Iterable = None,
-        options: Dict[str, Any] = {},
+        options: Optional[Dict[str, Any]] = None,
     ) -> "Minuit":
         """
         Minimize with SciPy algorithms.

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1052,7 +1052,7 @@ class Minuit:
             ncall = self._migrad_maxcall()
         
         if type(options) is not dict:
-            raise TypeError("options must be a dictionary")
+            raise ValueError("options must be a dictionary")
 
         cfree = ~np.array(self.fixed[:], dtype=bool)
         cpar = np.array(self.values[:])

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1017,7 +1017,7 @@ class Minuit:
             constraint.
         options : dict, optional
             A dictionary of solver options to pass to the SciPy minimizer through the
-            `options` parameter of :func:`scipy.optimize.minimize`. See each solver 
+            `options` parameter of :func:`scipy.optimize.minimize`. See each solver
             method for the options it accepts.
 
         Notes
@@ -1033,7 +1033,7 @@ class Minuit:
         means that usually SciPy minimizers will use more iterations than Migrad and
         the tolerance :attr:`tol` has no effect on SciPy minimizers.
 
-        You can specify convergance tolerance and other options for the SciPy minimizers  
+        You can specify convergance tolerance and other options for the SciPy minimizers
         through the `options` parameter.
         """
         try:
@@ -1050,7 +1050,7 @@ class Minuit:
 
         if ncall is None:
             ncall = self._migrad_maxcall()
-        
+
         if type(options) is not dict:
             raise ValueError("options must be a dictionary")
 
@@ -1248,7 +1248,7 @@ class Minuit:
         ):
             if "maxfev" not in options:
                 scipy_options["maxfev"] = ncall
-            
+
             if "maxiter" not in options:
                 del scipy_options["maxiter"]
 

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -258,7 +258,7 @@ def test_options():
     # simple example of uniform pdf with bounds on b to show tolerance
     # can be improved with options
     def density(x, b):
-        return b, np.full_like(x,b)
+        return b, np.full_like(x, b)
 
     # with empty data, b=0
     c = cost.ExtendedUnbinnedNLL([], density)
@@ -273,10 +273,10 @@ def test_options():
     # try using scipy options to show it is better
     c = cost.ExtendedUnbinnedNLL([], density)
 
-    m = Minuit(c,b=0)
+    m = Minuit(c, b=0)
     m.limits["b"] = (0, None)
 
-    m.scipy(method="Powell", options = {"xtol":1e-10, "ftol": 1e-10})
+    m.scipy(method="Powell", options={"xtol": 1e-10, "ftol": 1e-10})
     b_with_options = m.values["b"]
 
     assert b_without_options > b_with_options

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -254,16 +254,16 @@ def test_on_modified_state():
     assert m.valid
     assert_allclose(m.values, [0, 2], atol=1e-3)
 
+
 def test_options():
     # Create gaussian on flat background model, and place data right in the peak
     # The minimizer should return b=0 and s=1
     xr = (0, 2)
     sigma = 1
     mu = 1
+
     def density(x, s, b):
-        return s + b, (
-            s * truncnorm.pdf(x, *xr, mu, sigma) + b/xr[-1]
-        )
+        return s + b, (s * truncnorm.pdf(x, *xr, mu, sigma) + b / xr[-1])
 
     xdata = np.array([1])
     c = cost.ExtendedUnbinnedNLL(xdata, density)
@@ -281,7 +281,7 @@ def test_options():
     m = Minuit(c, s=1, b=0)
     m.limits["s", "b"] = (0, None)
 
-    m.scipy(method="Powell", options = {"xtol":1e-200, "ftol": 1e-200})
+    m.scipy(method="Powell", options={"xtol": 1e-200, "ftol": 1e-200})
     b_with_options = m.values["b"]
 
     assert b_without_options > b_with_options

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -231,12 +231,6 @@ def test_bad_constraint():
         m.scipy(constraints=[{}])
 
 
-def test_bad_options():
-    m = Minuit(fcn, a=1, b=2)
-    with pytest.raises(ValueError):
-        m.scipy(options=[])
-
-
 def test_high_print_level(capsys):
     m = Minuit(fcn, a=1, b=2)
     m.scipy()

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -231,6 +231,12 @@ def test_bad_constraint():
         m.scipy(constraints=[{}])
 
 
+def test_bad_options():
+    m = Minuit(fcn, a=1, b=2)
+    with pytest.raises(ValueError):
+        m.scipy(options=[])
+
+
 def test_high_print_level(capsys):
     m = Minuit(fcn, a=1, b=2)
     m.scipy()


### PR DESCRIPTION
The various SciPy minimizers have different options that can be adjusted to change and improve performance. Presently, the iminuit API does not allow passing options to these minimizers, which limits their usefulness for some minimization problems (specifically mine). I added a parameter to minuit.scipy() to allow passing options to scipy.optimize.minimize(). It keeps the existing default options that were being passed and allows for these defaults to be overwritten by the user.