### PR TITLE
Fix Qt widget sizing issues and simplify code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ no_implicit_optional = false
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-skip = ["cp39-musllinux_i686"] # no numpy wheel
+skip = ["cp39-musllinux_i686"]                    # no numpy wheel
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 test-skip = ["*universal2:arm64"]

--- a/tests/qtwidget_example.py
+++ b/tests/qtwidget_example.py
@@ -1,0 +1,29 @@
+"""Example for testing the QtWidget interactively."""
+
+from iminuit import cost
+from iminuit import Minuit
+from numba_stats import t
+import numpy as np
+
+
+def model(xe, s, mu, sigma, nuinv):
+    """Return model cdf."""
+    nu = 1 / nuinv
+    return s * t.cdf(xe, nu, mu, sigma)
+
+
+truth = 100.0, 0.5, 0.1, 0.5
+
+rng = np.random.default_rng(1)
+xe = np.linspace(0, 1, 20)
+m = np.diff(model(xe, *truth))
+n = rng.poisson(m)
+
+c = cost.ExtendedBinnedNLL(n, xe, model) + cost.NormalConstraint(
+    ["mu", "sigma"], [0.5, 0.1], [0.1, 0.1]
+)
+
+m = Minuit(c, *truth)
+m.limits["sigma", "s", "nuinv"] = (0, None)
+
+m.interactive()


### PR DESCRIPTION
Closes #1074 

The layout was changed so the parameters always take the minimal space. Font size was reduced to 11pt. The size of the result area was increased so that the full result can be seen on Windows.

The layout was not made user-adjustable, because parameters, buttons, and the result have fixed sizes anyway, so the only area with an adjustable size is the plot.

The code was simplified in a couple of places and some blocks refactored to functions to improve clarity.

Minimum and maximum values for each slider are taken from the Minuit.limits.