### PR TITLE
Add free-threading wheels (missing!)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest, ubuntu-24.04-arm, windows-11-arm]
-        py: [cp39, cp310, cp311, cp312, cp313, cp313t, cp314]
+        py: [cp39, cp310, cp311, cp312, cp313, cp313t, cp314, cp314t]
         exclude:
           - os: ubuntu-24.04-arm
             py: cp39

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,13 @@ jobs:
 
   wheels:
     needs: release_check
-    name: ${{ matrix.py }} ${{ matrix.os }} ${{ matrix.arch }}
+    name: ${{ matrix.py }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14, ubuntu-24.04-arm, windows-11-arm]
-        py: [cp39, cp310, cp311, cp312, cp313]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest, ubuntu-24.04-arm, windows-11-arm]
+        py: [cp39, cp310, cp311, cp312, cp313, cp313t]
         exclude:
           - os: ubuntu-24.04-arm
             py: cp39

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def pypy(session: nox.Session) -> None:
 @nox.session(venv_backend="uv", reuse_venv=True)
 def cov(session: nox.Session) -> None:
     """Run covage and place in 'htmlcov' directory."""
-    session.install("--only-binary=numpy", "-e.[test,doc]")
+    session.install("--only-binary=:all:", "-e.[test,doc]")
     session.run("coverage", "run", "-m", "pytest", env=ENV)
     session.run("coverage", "html", "-d", "build/htmlcov")
     session.run("coverage", "report", "-m")
@@ -80,7 +80,7 @@ def cov(session: nox.Session) -> None:
 @nox.session(python="3.11", reuse_venv=True)
 def doc(session: nox.Session) -> None:
     """Build html documentation."""
-    session.install("--only-binary=numpy", "-e.[test,doc]")
+    session.install("--only-binary=:all:", "-e.[test,doc]")
 
     # link check
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def pypy(session: nox.Session) -> None:
 @nox.session(venv_backend="uv", reuse_venv=True)
 def cov(session: nox.Session) -> None:
     """Run covage and place in 'htmlcov' directory."""
-    session.install("--only-binary=:all:", "-e.[test,doc]")
+    session.install("--only-binary=numpy", "-e.[test,doc]")
     session.run("coverage", "run", "-m", "pytest", env=ENV)
     session.run("coverage", "html", "-d", "build/htmlcov")
     session.run("coverage", "report", "-m")
@@ -80,7 +80,7 @@ def cov(session: nox.Session) -> None:
 @nox.session(python="3.11", reuse_venv=True)
 def doc(session: nox.Session) -> None:
     """Build html documentation."""
-    session.install("--only-binary=:all:", "-e.[test,doc]")
+    session.install("--only-binary=numpy", "-e.[test,doc]")
 
     # link check
     session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.12"]
+requires = ["scikit-build-core>=0.11", "pybind11>=3"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -125,7 +125,6 @@ build-frontend = "build[uv]"
 skip = ["cp39-musllinux_i686"]                    # no numpy wheel
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
-test-skip = ["*universal2:arm64"]
 enable = ["cpython-freethreading"]
 
 [tool.cibuildwheel.environment]
@@ -137,4 +136,4 @@ PIP_ONLY_BINARY = ":all:"
 # to match numpy, we use manylinux2014 for cp310 (and 3.9, since manylinux2010 is dead)
 select = "cp3{9,10}-manylinux*"
 manylinux-x86_64-image = "manylinux2014"
-build-frontend = "build"
+manylinux-i686-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.11", "pybind11 @ git+https://github.com/henryiii/pybind11@henryiii/fix/limitwarning"]
+requires = ["scikit-build-core>=0.11", "pybind11>=3.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.11", "pybind11>=3"]
+requires = ["scikit-build-core>=0.11", "pybind11 @ git+https://github.com/henryiii/pybind11@henryiii/fix/limitwarning"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
A little modernization, but mostly adding the missing 313t classifier to build free-threading wheels. If #1099 is merged first, this should be rebased, otherwise that one should be rebased. Also 314t should be added.
