### PR TITLE
chore: pytest log_level is better than log_cli_level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ sdist.include = [
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-q", "-ra", "--ff", "--strict-config", "--strict-markers"]
-log_cli_level = "INFO"
+log_level = "INFO"
 testpaths = ["tests"]
 xfail_strict = true
 filterwarnings = [


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

See https://github.com/scientific-python/cookie/issues/679

Note that there's not a practical difference, since `log_cli_level` doesn't trigger live logging if it's in a config file, but this is more conceptually correct (and maps to the CLI better, as `--log-cli-level` does trigger live logging).