### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
         python-version: "3.12"
     # without this, the Qt tests abort because a lib is missing
     - uses: tlambert03/setup-qt-libs@v1
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
     - run: uv pip install --system nox
     - run: nox -s cov
     - uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         python-version: "3.11"
     - run: sudo apt-get install pandoc
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
     - run: uv pip install --system nox
     - run: nox -s doc
     - uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
 
       - uses: pypa/cibuildwheel@v3.3
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.python-version }}
       - uses: rui314/setup-mold@v1
         if: runner.os == 'Linux'
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos