### PR TITLE
fix: bounds, lifetime, and equality bugs in C++ bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_CXX_EXTENSIONS OFF) # optional, keep compiler extensionsn off
 set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)
 
-file(GLOB SOURCES_A "src/*.cpp")
+file(GLOB SOURCES_A CONFIGURE_DEPENDS "src/*.cpp")
 # Keep in sync with tool.scikit-build.sdist.include in pyproject.toml
 set(SOURCES_B
     extern/root/math/mathcore/src/Util.cxx

--- a/src/contours.cpp
+++ b/src/contours.cpp
@@ -10,7 +10,8 @@ using namespace ROOT::Minuit2;
 void bind_contours(py::module m) {
   py::class_<MnContours>(m, "MnContours")
 
-      .def(py::init<const FCNBase&, const FunctionMinimum&, const MnStrategy&>())
+      .def(py::init<const FCNBase&, const FunctionMinimum&, const MnStrategy&>(),
+           py::keep_alive<1, 2>(), py::keep_alive<1, 3>())
       .def("__call__",
            [](const MnContours& self, unsigned ix, unsigned iy, unsigned npoints) {
              const auto ce = self.Contour(ix, iy, npoints);

--- a/src/equal.cpp
+++ b/src/equal.cpp
@@ -1,12 +1,6 @@
 #include "equal.hpp"
-#include <algorithm>
 #include <cmath>
-#include <vector>
 
-bool nan_equal(double a, double b) { return std::isnan(a) == std::isnan(b) || a == b; }
-
-namespace std {
-bool operator==(const vector<double>& a, const vector<double>& b) {
-  return equal(a.begin(), a.end(), b.begin(), b.end());
+bool nan_equal(double a, double b) {
+  return a == b || (std::isnan(a) && std::isnan(b));
 }
-} // namespace std

--- a/src/equal.hpp
+++ b/src/equal.hpp
@@ -1,13 +1,7 @@
 #ifndef IMINUIT_EQUAL_HPP
 #define IMINUIT_EQUAL_HPP
 
-#include <vector>
-
 bool nan_equal(double a, double b);
-
-namespace std {
-bool operator==(const vector<double>& a, const vector<double>& b);
-} // namespace std
 
 namespace ROOT {
 namespace Minuit2 {

--- a/src/hesse.cpp
+++ b/src/hesse.cpp
@@ -9,7 +9,7 @@ namespace py = pybind11;
 using namespace ROOT::Minuit2;
 
 void update_fmin(MnHesse& self, const FCNBase& fcn, FunctionMinimum& min,
-                 unsigned maxcalls, float maxedm) {
+                 unsigned maxcalls, double maxedm) {
   // We reset call counter here in contrast to MnHesse.cxx:83
   MnUserFcn mfcn(fcn, min.UserState().Trafo(), 0);
 

--- a/src/minos.cpp
+++ b/src/minos.cpp
@@ -30,7 +30,8 @@ void bind_minos(py::module m) {
 
   py::class_<MnMinos>(m, "MnMinos")
 
-      .def(py::init<const FCNBase&, const FunctionMinimum&, const MnStrategy&>())
+      .def(py::init<const FCNBase&, const FunctionMinimum&, const MnStrategy&>(),
+           py::keep_alive<1, 2>(), py::keep_alive<1, 3>())
       // int ipar, unsigned maxcalls, double toler
       .def("__call__", &MnMinos::Minos)
 

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -1,19 +1,33 @@
 #include "pybind11.hpp"
 #include <Minuit2/MnPrint.h>
+#include <string>
 
 namespace py = pybind11;
 using namespace ROOT::Minuit2;
 using cstr = const char*;
 using namespace pybind11::literals;
 
-void bind_print(py::module m) {
-  py::class_<MnPrint>(m, "MnPrint")
+// MnPrint stores the prefix as a `const char*` and keeps it on a stack for its
+// whole lifetime. We therefore must keep the prefix string alive as long as the
+// MnPrint object exists. This holder owns the string; since members are
+// destroyed in reverse order of declaration, `print` is destroyed before
+// `prefix`, so the pointer stays valid for MnPrint's lifetime.
+struct PyMnPrint {
+  std::string prefix;
+  MnPrint print;
 
-      .def(py::init<cstr, int>(), "prefix"_a, "level"_a)
-      .def("error", &MnPrint::Error<cstr>)
-      .def("warn", &MnPrint::Warn<cstr>)
-      .def("info", &MnPrint::Info<cstr>)
-      .def("debug", &MnPrint::Debug<cstr>)
+  PyMnPrint(std::string p, int level)
+      : prefix(std::move(p)), print(prefix.c_str(), level) {}
+};
+
+void bind_print(py::module m) {
+  py::class_<PyMnPrint>(m, "MnPrint")
+
+      .def(py::init<std::string, int>(), "prefix"_a, "level"_a)
+      .def("error", [](PyMnPrint& self, cstr msg) { self.print.Error(msg); })
+      .def("warn", [](PyMnPrint& self, cstr msg) { self.print.Warn(msg); })
+      .def("info", [](PyMnPrint& self, cstr msg) { self.print.Info(msg); })
+      .def("debug", [](PyMnPrint& self, cstr msg) { self.print.Debug(msg); })
       .def_property_static(
           "global_level", [](py::object) { return MnPrint::GlobalLevel(); },
           [](py::object, int x) { MnPrint::SetGlobalLevel(x); })

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -9,7 +9,8 @@ using namespace ROOT::Minuit2;
 void bind_scan(py::module m) {
   py::class_<MnScan, MnApplication>(m, "MnScan")
 
-      .def(py::init<const FCNBase&, const MnUserParameterState&, const MnStrategy&>())
+      .def(py::init<const FCNBase&, const MnUserParameterState&, const MnStrategy&>(),
+           py::keep_alive<1, 2>())
 
       ;
 }

--- a/src/usercovariance.cpp
+++ b/src/usercovariance.cpp
@@ -27,7 +27,12 @@ void bind_usercovariance(py::module m) {
 
       .def("__getitem__",
            [](const MnUserCovariance& self, py::object args) {
-             const auto tup = py::cast<std::pair<int, int>>(args);
+             auto tup = py::cast<std::pair<int, int>>(args);
+             const int n = static_cast<int>(self.Nrow());
+             if (tup.first < 0) tup.first += n;
+             if (tup.second < 0) tup.second += n;
+             if (tup.first < 0 || tup.first >= n || tup.second < 0 || tup.second >= n)
+               throw py::index_error();
              return self(tup.first, tup.second);
            })
 

--- a/src/userparameterstate.cpp
+++ b/src/userparameterstate.cpp
@@ -13,8 +13,8 @@ bool operator==(const MnUserParameterState& a, const MnUserParameterState& b) {
          a.IntParameters() == b.IntParameters() &&
          a.IntCovariance().Data() == b.IntCovariance().Data() &&
          a.CovarianceStatus() == b.CovarianceStatus() && a.IsValid() == b.IsValid() &&
-         a.HasCovariance() == b.HasCovariance() && a.Fval() == b.Fval() &&
-         a.Edm() == b.Edm() && a.NFcn() == b.NFcn();
+         a.HasCovariance() == b.HasCovariance() && a.Edm() == b.Edm() &&
+         a.NFcn() == b.NFcn();
 }
 
 } // namespace Minuit2
@@ -30,7 +30,7 @@ int size(const MnUserParameterState& self) {
 const MinuitParameter& getitem(const MnUserParameterState& self, int i) {
   const int n = size(self);
   if (i < 0) i += n;
-  if (i >= n) throw py::index_error();
+  if (i < 0 || i >= n) throw py::index_error();
   return self.Parameter(i);
 }
 
@@ -100,7 +100,7 @@ void bind_userparameterstate(py::module m) {
 
       .def("__len__", size)
       .def("__getitem__", getitem)
-      .def("__iter__", iter)
+      .def("__iter__", iter, py::keep_alive<0, 1>())
       .def(py::self == py::self)
 
       .def(py::pickle(

--- a/src/usertransformation.cpp
+++ b/src/usertransformation.cpp
@@ -52,7 +52,7 @@ void bind_usertransformation(py::module m) {
                              &MnUserTransformation::VariableParameters)
 
       .def("__len__", size)
-      .def("__iter__", iter)
+      .def("__iter__", iter, py::keep_alive<0, 1>())
       .def("__getitem__", getitem)
 
       .def(py::pickle(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+import gc
+
 from iminuit._core import (
     FCN,
     MnUserParameterState,
@@ -5,9 +7,11 @@ from iminuit._core import (
     MnMigrad,
     MnStrategy,
     MnScan,
+    MnMinos,
     FunctionMinimum,
     MnSimplex,
     MnUserCovariance,
+    MnPrint,
     MinimumState,
 )
 from pytest import approx
@@ -35,6 +39,15 @@ def test_MnUserCovariance():
     assert c[(1, 0)] == 2
     assert c[(0, 1)] == 2
     assert c[(1, 1)] == 3
+
+    # valid negative indices
+    assert c[(-1, -1)] == 3
+    assert c[(-2, -2)] == 1
+
+    # out-of-range indices raise instead of crashing
+    for bad in ((-3, 0), (0, -3), (2, 0), (0, 2)):
+        with pytest.raises(IndexError):
+            c[bad]
 
     pkl = pickle.dumps(c)
     c2 = pickle.loads(pkl)
@@ -74,6 +87,77 @@ def test_MnUserParameterState():
     st2.set_value(0, 1.1)
 
     assert st2 != st
+
+    # valid negative index works
+    assert st[-1].name == "😁"
+    assert st[-2].name == "x"
+
+    # out-of-range indices raise IndexError instead of crashing (SIGBUS)
+    for bad in (-(len(st) + 1), len(st)):
+        with pytest.raises(IndexError):
+            st[bad]
+
+
+def test_MnUserParameterState_limit_equality():
+    # parameters/states differing only in their limit values must not compare equal
+    a = MnUserParameterState()
+    a.add("x", 0, 1, -1, 5)
+    b = MnUserParameterState()
+    b.add("x", 0, 1, -2, 7)
+    assert a[0] != b[0]
+    assert a != b
+
+    c = MnUserParameterState()
+    c.add("x", 0, 1, -1, 5)
+    assert a[0] == c[0]
+    assert a == c
+
+
+def test_MnUserParameterState_iter_keep_alive():
+    # iterating over a temporary state must keep the state alive (keep_alive<0, 1>)
+    def make_params():
+        st = MnUserParameterState()
+        st.add("a", 1, 0.1)
+        st.add("b", 2, 0.1)
+        return iter(st)
+
+    it = make_params()
+    gc.collect()
+    names = [p.name for p in it]
+    assert names == ["a", "b"]
+
+
+def test_MnMinos_keep_alive():
+    # MnMinos stores references to the FCN and FunctionMinimum; constructing it
+    # from temporaries and dropping all other references must not crash.
+    def make_minos():
+        fcn = FCN(lambda x: 10 + x**2, None, None, None, False, 1)
+        state = MnUserParameterState()
+        state.add("x", 5, 0.1)
+        fmin = MnMigrad(fcn, state, 1)(0, 0.1)
+        return MnMinos(
+            FCN(lambda x: 10 + x**2, None, None, None, False, 1),
+            fmin,
+            MnStrategy(1),
+        )
+
+    minos = make_minos()
+    gc.collect()
+    err = minos(0, 100, 0.01)
+    assert err.lower == approx(-1, abs=1e-2)
+    assert err.upper == approx(1, abs=1e-2)
+
+
+def test_MnPrint_prefix():
+    # the prefix string must stay alive for the lifetime of the MnPrint object
+    prev = MnPrint.global_level
+    try:
+        p = MnPrint("some_prefix", 3)
+        # exercise the logging methods; they must not produce garbage/crash
+        p.info("hello")
+        p.warn("warning")
+    finally:
+        MnPrint.global_level = prev
 
 
 def test_MnMigrad():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses part of #1132.

This fixes a set of reviewed, pre-verified bugs in the pybind11 bindings (several reproduced as interpreter crashes), plus a few small simplifications. Adds Python-level regression tests in `tests/test_core.py`.

## Crash / correctness fixes

1. **Out-of-range negative index → SIGBUS** (`src/userparameterstate.cpp`): `getitem` adjusted a negative index but never re-checked `i < 0`, so `state[-(n+1)]` fed a negative int into `Parameter(unsigned)` and crashed the interpreter. Now re-checks `if (i < 0 || i >= n) throw py::index_error();`, matching `usertransformation.cpp`. `MnUserCovariance.__getitem__` (`src/usercovariance.cpp`) had **no** bounds check at all — added range checks for both indices with negative-index support.
2. **`nan_equal` tautology** (`src/equal.cpp`): `std::isnan(a) == std::isnan(b) || a == b` is true for *any* two non-NaN values, so `MinuitParameter::operator==` never actually compared limit values (states with limits `(-1, 5)` vs `(-2, 7)` compared equal). Now `a == b || (std::isnan(a) && std::isnan(b))`.
3. **Missing `keep_alive` → segfault** (`src/minos.cpp`, `src/contours.cpp`, `src/scan.cpp`): `MnMinos`/`MnContours` store `const FCNBase&` and `const FunctionMinimum&` references, `MnScan` stores `const FCNBase&`. Added `py::keep_alive<1, 2>()` (FCN) to all three and `py::keep_alive<1, 3>()` (FunctionMinimum) to `MnMinos`/`MnContours`, matching `migrad.cpp`/`simplex.cpp`.
4. **`__iter__` missing `keep_alive<0, 1>`** (`src/userparameterstate.cpp`, `src/usertransformation.cpp`): `py::make_iterator` over the internal vector without keeping the parent alive. Added `keep_alive<0, 1>()` to both.
5. **`MnPrint` dangling prefix** (`src/print.cpp`): `py::init<cstr, int>()` stored a `const char*` owned by a dead temporary (the prefix is pushed onto a long-lived stack), producing garbage / `UnicodeDecodeError`. Replaced with a `PyMnPrint` holder struct that owns a `std::string` outliving the contained `MnPrint`. Class-level statics (`global_level`, `show_prefix_stack`, `add_filter`, `clear_filter`) and the Python API are unchanged.
6. **`update_fmin` float vs double** (`src/hesse.cpp`): `float maxedm` silently narrowed the Python-side `edm_goal`; changed to `double`.

## Simplifications

7a. `MnUserParameterState::operator==` compared `Fval()` twice — removed the duplicate.
7b. Deleted the `std::operator==(const vector<double>&, ...)` overload added to namespace `std` (duplicates the standard operator and is formally UB); all call sites resolve to the std one and everything compiles.
7c. `CMakeLists.txt`: added `CONFIGURE_DEPENDS` to the `src/*.cpp` glob.

## Tests added (`tests/test_core.py`)

- `test_MnUserCovariance`: valid negative indices, and out-of-range indices raise `IndexError`.
- `test_MnUserParameterState`: valid negative index, out-of-range raises `IndexError`.
- `test_MnUserParameterState_limit_equality`: parameters/states differing only in limit values are not equal.
- `test_MnUserParameterState_iter_keep_alive`: iterating a temporary state.
- `test_MnMinos_keep_alive`: construct `MnMinos` from temporary FCN/FunctionMinimum, drop all other refs, run minos.
- `test_MnPrint_prefix`: construct and log without garbage/crash.

## Notes

- All findings held on re-verification; nothing was skipped.
- Full suite passes except `tests/test_tabulate.py::test_params`, which fails identically on `develop` without these changes (a `tabulate` library version whitespace difference, unrelated to this PR).
- The `check-root-version` pre-commit hook reports a mismatch (`...g56be091a18` vs `...g56be091a18c`) due to the local git short-hash length; this is a pre-existing discrepancy in `doc/conf.py` and unrelated to these changes, so it was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)