### PR TITLE
chore: drop Python 3.9, require 3.10+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-26-intel, macos-latest, ubuntu-24.04-arm, windows-11-arm]
-        py: [cp39, cp310, cp311, cp312, cp313, cp314, cp314t]
+        py: [cp310, cp311, cp312, cp313, cp314, cp314t]
         exclude:
-          - os: ubuntu-24.04-arm
-            py: cp39
-          - os: windows-11-arm
-            py: cp39
           - os: windows-11-arm
             py: cp310
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
             python-version: "3.12"
             installs: "numpy>=2"
           - os: macos-14
-            python-version: "3.9"
-            installs: "numpy==1.21.0 scipy matplotlib"
+            python-version: "3.10"
+            installs: "numpy==1.21.3 scipy matplotlib"
           - os: ubuntu-latest
             python-version: "pypy-3.11"
           - os: ubuntu-latest

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ from iminuit import __version__ as version
 # via the local pre-commit hook check-root-version, which will
 # fail if this version number does not correspond to the actual
 # version.
-root_version = "v6-37-01-8658-g56be091a18"
+root_version = "v6-37-01-8658-g56be091a18c"
 
 
 with open("../README.rst") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Jupyter-friendly Python frontend for MINUIT2 in C++"
 version = "2.32.0"
 maintainers = [{ name = "Hans Dembinski", email = "hans.dembinski@gmail.com" }]
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "MIT+LGPL" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -20,6 +20,10 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development",
@@ -30,7 +34,7 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dependencies = ["numpy >=1.21"]
+dependencies = ["numpy >=1.21.3"]
 
 [project.urls]
 repository = "http://github.com/scikit-hep/iminuit"
@@ -129,7 +133,7 @@ no_implicit_optional = false
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-skip = ["cp39-musllinux_i686"]                    # no numpy wheel
+skip = ["cp310-musllinux_i686"]                   # no numpy wheel
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 
@@ -139,7 +143,7 @@ UV_ONLY_BINARY = ":all:"
 PIP_ONLY_BINARY = ":all:"
 
 [[tool.cibuildwheel.overrides]]
-# to match numpy, we use manylinux2014 for cp310 (and 3.9, since manylinux2010 is dead)
-select = "cp3{9,10}-manylinux*"
+# to match numpy, we use manylinux2014 for cp310
+select = "cp310-manylinux*"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"

--- a/src/iminuit/_deprecated.py
+++ b/src/iminuit/_deprecated.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import Callable, Any
+from typing import Any
+from collections.abc import Callable
 from importlib.metadata import version
 from iminuit._parse_version import parse_version
 

--- a/src/iminuit/_optional_dependencies.py
+++ b/src/iminuit/_optional_dependencies.py
@@ -1,12 +1,11 @@
 import contextlib
 import warnings
 from iminuit.warnings import OptionalDependencyWarning
-from typing import Dict, Optional
 
 
 @contextlib.contextmanager
 def optional_module_for(
-    functionality: str, *, replace: Optional[Dict[str, str]] = None, stacklevel: int = 3
+    functionality: str, *, replace: dict[str, str] | None = None, stacklevel: int = 3
 ):
     try:
         yield

--- a/src/iminuit/_parse_version.py
+++ b/src/iminuit/_parse_version.py
@@ -1,8 +1,7 @@
 import re
-from typing import Tuple, Union
 
 
-def parse_version(s: str) -> Union[Tuple[int, int], Tuple[int, int, int]]:
+def parse_version(s: str) -> tuple[int, int] | tuple[int, int, int]:
     """
     Parse version string and return tuple of integer parts to allow for comparison.
 

--- a/src/iminuit/_repr_html.py
+++ b/src/iminuit/_repr_html.py
@@ -68,7 +68,7 @@ def tag(name, *args, **kwargs):
     if len(args) == 0:
         return [head + tail]
     if len(args) == 1 and isinstance(args[0], str):
-        return ["{} {} {}".format(head, args[0], tail)]
+        return [f"{head} {args[0]} {tail}"]
     return [head, *args, tail]
 
 

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -97,19 +97,11 @@ from numpy.typing import NDArray, ArrayLike
 from collections.abc import Sequence as ABCSequence
 import abc
 from typing import (
-    List,
-    Tuple,
-    Union,
-    Sequence,
-    Collection,
-    Dict,
     Any,
-    Iterable,
-    Optional,
     TypeVar,
-    Callable,
     cast,
 )
+from collections.abc import Sequence, Collection, Iterable, Callable
 import warnings
 from ._deprecated import deprecated_parameter
 
@@ -502,7 +494,7 @@ class Cost(abc.ABC):
 
     __slots__ = ("_parameters", "_verbose")
 
-    _parameters: Dict[str, Optional[Tuple[float, float]]]
+    _parameters: dict[str, tuple[float, float] | None]
     _verbose: int
 
     @property
@@ -549,9 +541,7 @@ class Cost(abc.ABC):
     def verbose(self, value: int):
         self._verbose = value
 
-    def __init__(
-        self, parameters: Dict[str, Optional[Tuple[float, float]]], verbose: int
-    ):
+    def __init__(self, parameters: dict[str, tuple[float, float] | None], verbose: int):
         """For internal use."""
         self._parameters = parameters
         self._verbose = verbose
@@ -686,7 +676,7 @@ class CostSum(Cost, ABCSequence):
 
     __slots__ = "_items", "_maps"
 
-    def __init__(self, *items: Union[Cost, float]):
+    def __init__(self, *items: Cost | float):
         """
         Initialize with cost functions.
 
@@ -695,7 +685,7 @@ class CostSum(Cost, ABCSequence):
         *items : Cost
             Cost functions. May also be other CostSum functions.
         """
-        self._items: List[Cost] = []
+        self._items: list[Cost] = []
         for item in items:
             if isinstance(item, CostSum):
                 self._items += item._items
@@ -740,7 +730,7 @@ class CostSum(Cost, ABCSequence):
         return self._items.__getitem__(key)
 
     def visualize(
-        self, args: Sequence[float], component_kwargs: Dict[int, Dict[str, Any]] = None
+        self, args: Sequence[float], component_kwargs: dict[int, dict[str, Any]] = None
     ):
         """
         Visualize data and model agreement (requires matplotlib).
@@ -791,11 +781,11 @@ class MaskedCost(Cost):
 
     __slots__ = "_data", "_mask", "_masked"
 
-    _mask: Optional[NDArray]
+    _mask: NDArray | None
 
     def __init__(
         self,
-        parameters: Dict[str, Optional[Tuple[float, float]]],
+        parameters: dict[str, tuple[float, float] | None],
         data: NDArray,
         verbose: int,
     ):
@@ -816,7 +806,7 @@ class MaskedCost(Cost):
         return self._mask
 
     @mask.setter
-    def mask(self, mask: Optional[ArrayLike]):
+    def mask(self, mask: ArrayLike | None):
         self._mask = None if mask is None else np.asarray(mask)
         self._update_cache()
 
@@ -898,8 +888,8 @@ class UnbinnedCost(MaskedCost):
         model: Model,
         verbose: int,
         log: bool,
-        grad: Optional[ModelGradient],
-        name: Optional[Sequence[str]],
+        grad: ModelGradient | None,
+        name: Sequence[str] | None,
     ):
         """For internal use."""
         self._model = model
@@ -930,7 +920,7 @@ class UnbinnedCost(MaskedCost):
     def visualize(
         self,
         args: Sequence[float],
-        model_points: Union[int, Sequence[float]] = 0,
+        model_points: int | Sequence[float] = 0,
         bins: int = 50,
     ):
         """
@@ -1054,8 +1044,8 @@ class UnbinnedNLL(UnbinnedCost):
         *,
         verbose: int = 0,
         log: bool = False,
-        grad: Optional[ModelGradient] = None,
-        name: Optional[Sequence[str]] = None,
+        grad: ModelGradient | None = None,
+        name: Sequence[str] | None = None,
     ):
         """
         Initialize UnbinnedNLL with data and model.
@@ -1166,8 +1156,8 @@ class ExtendedUnbinnedNLL(UnbinnedCost):
         *,
         verbose: int = 0,
         log: bool = False,
-        grad: Optional[ModelGradient] = None,
-        name: Optional[Sequence[str]] = None,
+        grad: ModelGradient | None = None,
+        name: Sequence[str] | None = None,
     ):
         """
         Initialize cost function with data and model.
@@ -1230,13 +1220,13 @@ class ExtendedUnbinnedNLL(UnbinnedCost):
         _, f = self._eval_model(args)
         return g / f - (gint / m)[:, np.newaxis]
 
-    def _eval_model(self, args: Sequence[float]) -> Tuple[float, float]:
+    def _eval_model(self, args: Sequence[float]) -> tuple[float, float]:
         data = self._masked
         fint, f = self._model(data, *args)
         f = _normalize_output(f, "model", self._npoints(), msg="in second position")
         return fint, f
 
-    def _eval_model_grad(self, args: Sequence[float]) -> Tuple[NDArray, NDArray]:
+    def _eval_model_grad(self, args: Sequence[float]) -> tuple[NDArray, NDArray]:
         if self._model_grad is None:
             raise ValueError("no gradient available")  # pragma: no cover
         data = self._masked
@@ -1307,10 +1297,10 @@ class BinnedCost(MaskedCostWithPulls):
 
     __slots__ = "_xe", "_ndim", "_bohm_zech_n", "_bohm_zech_s"
 
-    _xe: Union[NDArray, Tuple[NDArray, ...]]
+    _xe: NDArray | tuple[NDArray, ...]
     _ndim: int
     _bohm_zech_n: NDArray
-    _bohm_zech_s: Optional[NDArray]
+    _bohm_zech_s: NDArray | None
 
     n = MaskedCost.data
 
@@ -1321,9 +1311,9 @@ class BinnedCost(MaskedCostWithPulls):
 
     def __init__(
         self,
-        parameters: Dict[str, Optional[Tuple[float, float]]],
+        parameters: dict[str, tuple[float, float] | None],
         n: ArrayLike,
-        xe: Union[ArrayLike, Sequence[ArrayLike]],
+        xe: ArrayLike | Sequence[ArrayLike],
         verbose: int,
     ):
         """For internal use."""
@@ -1357,9 +1347,7 @@ class BinnedCost(MaskedCostWithPulls):
         self._bohm_zech_s = np.zeros(0) if is_weighted else None
         super().__init__(parameters, n, verbose)
 
-    def prediction(
-        self, args: Sequence[float]
-    ) -> Union[NDArray, Tuple[NDArray, NDArray]]:
+    def prediction(self, args: Sequence[float]) -> NDArray | tuple[NDArray, NDArray]:
         """
         Return the bin-wise expectation for the fitted model.
 
@@ -1421,9 +1409,9 @@ class BinnedCost(MaskedCostWithPulls):
     @abc.abstractmethod
     def _pred(
         self, args: Sequence[float]
-    ) -> Union[NDArray, Tuple[NDArray, NDArray]]: ...  # pragma: no cover
+    ) -> NDArray | tuple[NDArray, NDArray]: ...  # pragma: no cover
 
-    def _n_err(self) -> Tuple[NDArray, NDArray]:
+    def _n_err(self) -> tuple[NDArray, NDArray]:
         d = self.data
         if self._bohm_zech_s is None:
             n = d.copy()
@@ -1461,7 +1449,7 @@ class BinnedCost(MaskedCostWithPulls):
         else:
             self._bohm_zech_n = n
 
-    def _transformed(self, val: NDArray) -> Tuple[NDArray, NDArray]:
+    def _transformed(self, val: NDArray) -> tuple[NDArray, NDArray]:
         s = self._bohm_zech_s
         ma = self.mask
         if ma is not None:
@@ -1473,7 +1461,7 @@ class BinnedCost(MaskedCostWithPulls):
 
     def _transformed2(
         self, val: NDArray, var: NDArray
-    ) -> Tuple[NDArray, NDArray, NDArray]:
+    ) -> tuple[NDArray, NDArray, NDArray]:
         s = self._bohm_zech_s
         ma = self.mask
         if ma is not None:
@@ -1509,7 +1497,7 @@ class BinnedCostWithModel(BinnedCost):
     )
 
     _model_xe: np.ndarray
-    _xe_shape: Union[Tuple[int], Tuple[int, ...]]
+    _xe_shape: tuple[int] | tuple[int, ...]
 
     def __init__(self, n, xe, model, verbose, grad, use_pdf, name):
         """For internal use."""
@@ -1657,22 +1645,17 @@ class Template(BinnedCost):
 
     __slots__ = "_model_data", "_model_xe", "_xe_shape", "_impl", "_model_len"
 
-    _model_data: List[
-        Union[
-            Tuple[NDArray, NDArray],
-            Tuple[Model, float],
-        ]
-    ]
+    _model_data: list[tuple[NDArray, NDArray] | tuple[Model, float]]
     _model_xe: np.ndarray
-    _xe_shape: Union[Tuple[int], Tuple[int, ...]]
+    _xe_shape: tuple[int] | tuple[int, ...]
 
     def __init__(
         self,
         n: ArrayLike,
-        xe: Union[ArrayLike, Sequence[ArrayLike]],
-        model_or_template: Collection[Union[Model, ArrayLike]],
+        xe: ArrayLike | Sequence[ArrayLike],
+        model_or_template: Collection[Model | ArrayLike],
         *,
-        name: Optional[Sequence[str]] = None,
+        name: Sequence[str] | None = None,
         verbose: int = 0,
         method: str = "da",
     ):
@@ -1718,7 +1701,7 @@ class Template(BinnedCost):
         ndim = len(shape)
 
         npar = 0
-        annotated: Dict[str, Optional[Tuple[float, float]]] = {}
+        annotated: dict[str, tuple[float, float] | None] = {}
         self._model_data = []
         for i, t in enumerate(model_or_template):
             if isinstance(t, Collection):
@@ -1792,7 +1775,7 @@ class Template(BinnedCost):
             )
         self._model_len = np.prod(self._xe_shape)
 
-    def _pred(self, args: Sequence[float]) -> Tuple[NDArray, NDArray]:
+    def _pred(self, args: Sequence[float]) -> tuple[NDArray, NDArray]:
         mu: NDArray = 0  # type:ignore
         mu_var: NDArray = 0  # type:ignore
         i = 0
@@ -1834,7 +1817,7 @@ class Template(BinnedCost):
     def _errordef(self) -> float:
         return NEGATIVE_LOG_LIKELIHOOD if self._impl is template_nll_asy else CHISQUARE
 
-    def prediction(self, args: Sequence[float]) -> Tuple[NDArray, NDArray]:
+    def prediction(self, args: Sequence[float]) -> tuple[NDArray, NDArray]:
         """
         Return the fitted template and its standard deviation.
 
@@ -1922,13 +1905,13 @@ class BinnedNLL(BinnedCostWithModel):
     def __init__(
         self,
         n: ArrayLike,
-        xe: Union[ArrayLike, Sequence[ArrayLike]],
+        xe: ArrayLike | Sequence[ArrayLike],
         cdf: Model,
         *,
         verbose: int = 0,
-        grad: Optional[ModelGradient] = None,
+        grad: ModelGradient | None = None,
         use_pdf: str = "",
-        name: Optional[Sequence[str]] = None,
+        name: Sequence[str] | None = None,
     ):
         """
         Initialize cost function with data and model.
@@ -2051,13 +2034,13 @@ class ExtendedBinnedNLL(BinnedCostWithModel):
     def __init__(
         self,
         n: ArrayLike,
-        xe: Union[ArrayLike, Sequence[ArrayLike]],
+        xe: ArrayLike | Sequence[ArrayLike],
         scaled_cdf: Model,
         *,
         verbose: int = 0,
-        grad: Optional[ModelGradient] = None,
+        grad: ModelGradient | None = None,
         use_pdf: str = "",
-        name: Optional[Sequence[str]] = None,
+        name: Sequence[str] | None = None,
     ):
         """
         Initialize cost function with data and model.
@@ -2135,11 +2118,11 @@ class LeastSquares(MaskedCostWithPulls):
 
     __slots__ = "_loss", "_cost", "_cost_grad", "_model", "_model_grad", "_ndim"
 
-    _loss: Union[str, LossFunction]
+    _loss: str | LossFunction
     _cost: Callable[[ArrayLike, ArrayLike, ArrayLike], float]
-    _cost_grad: Optional[Callable[[NDArray, NDArray, NDArray, NDArray], NDArray]]
+    _cost_grad: Callable[[NDArray, NDArray, NDArray, NDArray], NDArray] | None
     _model: Model
-    _model_grad: Optional[ModelGradient]
+    _model_grad: ModelGradient | None
     _ndim: int
 
     @property
@@ -2193,7 +2176,7 @@ class LeastSquares(MaskedCostWithPulls):
         return self._loss
 
     @loss.setter
-    def loss(self, loss: Union[str, LossFunction]):
+    def loss(self, loss: str | LossFunction):
         self._loss = loss
         if isinstance(loss, str):
             if loss == "linear":
@@ -2219,10 +2202,10 @@ class LeastSquares(MaskedCostWithPulls):
         yerror: ArrayLike,
         model: Model,
         *,
-        loss: Union[str, LossFunction] = "linear",
+        loss: str | LossFunction = "linear",
         verbose: int = 0,
-        grad: Optional[ModelGradient] = None,
-        name: Optional[Sequence[str]] = None,
+        grad: ModelGradient | None = None,
+        name: Sequence[str] | None = None,
     ):
         """
         Initialize cost function with data and model.
@@ -2282,8 +2265,8 @@ class LeastSquares(MaskedCostWithPulls):
         return len(self._masked)
 
     def visualize(
-        self, args: ArrayLike, model_points: Union[int, Sequence[float]] = 0
-    ) -> Tuple[Tuple[NDArray, NDArray, NDArray], Tuple[NDArray, NDArray]]:
+        self, args: ArrayLike, model_points: int | Sequence[float] = 0
+    ) -> tuple[tuple[NDArray, NDArray, NDArray], tuple[NDArray, NDArray]]:
         """
         Visualize data and model agreement (requires matplotlib).
 
@@ -2409,7 +2392,7 @@ class NormalConstraint(Cost):
 
     def __init__(
         self,
-        args: Union[str, Iterable[str]],
+        args: str | Iterable[str],
         value: ArrayLike,
         error: ArrayLike,
     ):

--- a/src/iminuit/ipywidget.py
+++ b/src/iminuit/ipywidget.py
@@ -3,7 +3,8 @@
 from .util import _widget_guess_initial_step, _make_finite
 import warnings
 import numpy as np
-from typing import Dict, Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 with warnings.catch_warnings():
     # ipywidgets produces deprecation warnings through use of internal APIs :(
@@ -24,7 +25,7 @@ with warnings.catch_warnings():
 def make_widget(
     minuit: Any,
     plot: Callable[..., None],
-    kwargs: Dict[str, Any],
+    kwargs: dict[str, Any],
     raise_on_exception: bool,
 ):
     """Make interactive fitting widget."""
@@ -97,7 +98,7 @@ def make_widget(
         def __init__(self, skip: int = 0):
             self.skip = skip
 
-        def __call__(self, change: Dict[str, Any] = {}):
+        def __call__(self, change: dict[str, Any] = {}):
             if self.skip > 0:
                 self.skip -= 1
                 return

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -21,18 +21,9 @@ from iminuit._core import (
 from iminuit.warnings import ErrordefAlreadySetWarning, IMinuitWarning
 import numpy as np
 from typing import (
-    Union,
-    Optional,
-    Callable,
-    Tuple,
-    List,
-    Dict,
-    Iterable,
     Any,
-    Collection,
-    Set,
-    Sized,
 )
+from collections.abc import Callable, Iterable, Collection, Sized
 from iminuit.typing import UserBound, Cost, CostVector
 from iminuit._optional_dependencies import optional_module_for
 from numpy.typing import ArrayLike
@@ -63,8 +54,8 @@ class Minuit:
         "_last_state",
     )
 
-    _fmin: Optional[mutil.FMin]
-    _covariance: Optional[mutil.Matrix]
+    _fmin: mutil.FMin | None
+    _covariance: mutil.Matrix | None
 
     # Set errordef to this for a least-squares cost function.
     LEAST_SQUARES = 1.0
@@ -93,17 +84,17 @@ class Minuit:
         return self._fcn.hessian  # type:ignore
 
     @property
-    def pos2var(self) -> Tuple[str, ...]:
+    def pos2var(self) -> tuple[str, ...]:
         """Map variable index to name."""
         return self._pos2var
 
     @property
-    def var2pos(self) -> Dict[str, int]:
+    def var2pos(self) -> dict[str, int]:
         """Map variable name to index."""
         return self._var2pos
 
     @property
-    def parameters(self) -> Tuple[str, ...]:
+    def parameters(self) -> tuple[str, ...]:
         """
         Get tuple of parameter names.
 
@@ -154,7 +145,7 @@ class Minuit:
             self._fmin._src.errordef = value
 
     @property
-    def precision(self) -> Optional[float]:
+    def precision(self) -> float | None:
         """
         Access estimated precision of the cost function.
 
@@ -166,7 +157,7 @@ class Minuit:
         return self._precision
 
     @precision.setter
-    def precision(self, value: Optional[float]) -> None:
+    def precision(self, value: float | None) -> None:
         if value is not None and not (value > 0):
             raise ValueError("precision must be a positive number or None")
         self._precision = value
@@ -205,7 +196,7 @@ class Minuit:
         return self._tolerance
 
     @tol.setter
-    def tol(self, value: Optional[float]) -> None:
+    def tol(self, value: float | None) -> None:
         if value is None:  # used to reset tolerance
             value = 0.1
         elif value < 0:
@@ -378,7 +369,7 @@ class Minuit:
         return self._merrors
 
     @property
-    def covariance(self) -> Optional[mutil.Matrix]:
+    def covariance(self) -> mutil.Matrix | None:
         r"""
         Return covariance matrix.
 
@@ -428,7 +419,7 @@ class Minuit:
         return self._fcn._ndata() - self.nfit  # type: ignore
 
     @property
-    def fmin(self) -> Optional[mutil.FMin]:
+    def fmin(self) -> mutil.FMin | None:
         """
         Get function minimum data object.
 
@@ -439,7 +430,7 @@ class Minuit:
         return self._fmin
 
     @property
-    def fval(self) -> Optional[float]:
+    def fval(self) -> float | None:
         """
         Get function value at minimum.
 
@@ -523,11 +514,11 @@ class Minuit:
     def __init__(
         self,
         fcn: Cost,
-        *args: Union[float, ArrayLike],
-        grad: Union[CostVector, bool, None] = None,
-        g2: Union[CostVector, bool, None] = None,
-        hessian: Union[CostVector, bool, None] = None,
-        name: Optional[Collection[str]] = None,
+        *args: float | ArrayLike,
+        grad: CostVector | bool | None = None,
+        g2: CostVector | bool | None = None,
+        hessian: CostVector | bool | None = None,
+        name: Collection[str] | None = None,
         **kwds: float,
     ):
         """
@@ -757,7 +748,7 @@ class Minuit:
             if lim is not None:
                 self.limits[k] = lim
 
-    def fixto(self, key: mutil.Key, value: Union[float, Iterable[float]]) -> "Minuit":
+    def fixto(self, key: mutil.Key, value: float | Iterable[float]) -> Minuit:
         """
         Fix parameter and set it to value.
 
@@ -792,7 +783,7 @@ class Minuit:
             self._last_state.set_value(index, value)
         return self  # return self for method chaining
 
-    def reset(self) -> "Minuit":
+    def reset(self) -> Minuit:
         """
         Reset minimization state to initial state.
 
@@ -809,10 +800,10 @@ class Minuit:
 
     def migrad(
         self,
-        ncall: Optional[int] = None,
+        ncall: int | None = None,
         iterate: int = 5,
         use_simplex: bool = True,
-    ) -> "Minuit":
+    ) -> Minuit:
         """
         Run Migrad minimization.
 
@@ -877,7 +868,7 @@ class Minuit:
 
         return self  # return self for method chaining and to autodisplay current state
 
-    def simplex(self, ncall: Optional[int] = None) -> "Minuit":
+    def simplex(self, ncall: int | None = None) -> Minuit:
         """
         Run Simplex minimization.
 
@@ -937,7 +928,7 @@ class Minuit:
 
         return self  # return self for method chaining and to autodisplay current state
 
-    def scan(self, ncall: Optional[int] = None) -> "Minuit":
+    def scan(self, ncall: int | None = None) -> Minuit:
         """
         Brute-force minimization.
 
@@ -1051,13 +1042,13 @@ class Minuit:
 
     def scipy(
         self,
-        method: Union[str, Callable] = None,
-        ncall: Optional[int] = None,
+        method: str | Callable | None = None,
+        ncall: int | None = None,
         hess: Any = None,
         hessp: Any = None,
         constraints: Iterable = None,
-        options: Optional[Dict[str, Any]] = None,
-    ) -> "Minuit":
+        options: dict[str, Any] | None = None,
+    ) -> Minuit:
         """
         Minimize with SciPy algorithms.
 
@@ -1470,7 +1461,7 @@ class Minuit:
         """
         return self._visualize(plot)(self.values, **kwargs)
 
-    def hesse(self, ncall: Optional[int] = None) -> "Minuit":
+    def hesse(self, ncall: int | None = None) -> Minuit:
         """
         Run Hesse algorithm to compute asymptotic errors.
 
@@ -1565,10 +1556,10 @@ class Minuit:
 
     def minos(
         self,
-        *parameters: Union[int, str],
+        *parameters: int | str,
         cl: float = None,
-        ncall: Optional[int] = None,
-    ) -> "Minuit":
+        ncall: int | None = None,
+    ) -> Minuit:
         """
         Run Minos algorithm to compute confidence intervals.
 
@@ -1674,16 +1665,16 @@ class Minuit:
 
     def mnprofile(
         self,
-        vname: Union[int, str],
+        vname: int | str,
         *,
         size: int = 30,
-        bound: Union[float, UserBound] = 2,
+        bound: float | UserBound = 2,
         grid: ArrayLike = None,
         subtract_min: bool = False,
         ncall: int = 0,
         iterate: int = 5,
         use_simplex: bool = True,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         r"""
         Get Minos profile over a specified interval.
 
@@ -1777,8 +1768,8 @@ class Minuit:
         return x, y, status
 
     def draw_mnprofile(
-        self, vname: Union[int, str], *, band: bool = True, text: bool = True, **kwargs
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        self, vname: int | str, *, band: bool = True, text: bool = True, **kwargs
+    ) -> tuple[np.ndarray, np.ndarray]:
         r"""
         Draw Minos profile over a specified interval (requires matplotlib).
 
@@ -1815,13 +1806,13 @@ class Minuit:
 
     def profile(
         self,
-        vname: Union[int, str],
+        vname: int | str,
         *,
         size: int = 100,
-        bound: Union[float, UserBound] = 2,
+        bound: float | UserBound = 2,
         grid: ArrayLike = None,
         subtract_min: bool = False,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         r"""
         Calculate 1D cost function profile over a range.
 
@@ -1879,8 +1870,8 @@ class Minuit:
         return x, y
 
     def draw_profile(
-        self, vname: Union[int, str], *, band: bool = True, text: bool = True, **kwargs
-    ) -> Tuple[np.ndarray, np.ndarray]:
+        self, vname: int | str, *, band: bool = True, text: bool = True, **kwargs
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Draw 1D cost function profile over a range (requires matplotlib).
 
@@ -1915,7 +1906,7 @@ class Minuit:
         y: np.ndarray,
         band: bool,
         text: bool,
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         from matplotlib import pyplot as plt
 
         pname = self._pos2var[ipar]
@@ -1943,11 +1934,7 @@ class Minuit:
                 (
                     (f"{pname} = {v:.3g}")
                     if vmin is None
-                    else (
-                        "{} = {:.3g} - {:.3g} + {:.3g}".format(
-                            pname, v, v - vmin, vmax - v
-                        )
-                    )
+                    else (f"{pname} = {v:.3g} - {v - vmin:.3g} + {vmax - v:.3g}")
                 ),
                 fontsize="large",
             )
@@ -1956,14 +1943,14 @@ class Minuit:
 
     def contour(
         self,
-        x: Union[int, str],
-        y: Union[int, str],
+        x: int | str,
+        y: int | str,
         *,
         size: int = 50,
-        bound: Union[float, Iterable[Tuple[float, float]]] = 2,
-        grid: Tuple[ArrayLike, ArrayLike] = None,
+        bound: float | Iterable[tuple[float, float]] = 2,
+        grid: tuple[ArrayLike, ArrayLike] = None,
         subtract_min: bool = False,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         r"""
         Get a 2D contour of the function around the minimum.
 
@@ -2053,10 +2040,10 @@ class Minuit:
 
     def draw_contour(
         self,
-        x: Union[int, str],
-        y: Union[int, str],
+        x: int | str,
+        y: int | str,
         **kwargs,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Draw 2D contour around minimum (requires matplotlib).
 
@@ -2090,8 +2077,8 @@ class Minuit:
 
     def mncontour(
         self,
-        x: Union[int, str],
-        y: Union[int, str],
+        x: int | str,
+        y: int | str,
         *,
         cl: float = None,
         size: int = 100,
@@ -2218,10 +2205,10 @@ class Minuit:
 
     def draw_mncontour(
         self,
-        x: Union[int, str],
-        y: Union[int, str],
+        x: int | str,
+        y: int | str,
         *,
-        cl: Union[float, ArrayLike] = None,
+        cl: float | ArrayLike = None,
         size: int = 100,
         interpolated: int = 0,
         experimental: bool = False,
@@ -2288,7 +2275,7 @@ class Minuit:
     def draw_mnmatrix(
         self,
         *,
-        cl: Union[float, ArrayLike] = None,
+        cl: float | ArrayLike = None,
         size: int = 100,
         experimental: bool = False,
         figsize=None,
@@ -2470,7 +2457,7 @@ class Minuit:
 
         return make_widget(self, plot, kwargs, raise_on_exception)
 
-    def _free_parameters(self) -> Set[str]:
+    def _free_parameters(self) -> set[str]:
         return set(mp.name for mp in self._last_state if not mp.is_fixed)
 
     def _mnprecision(self) -> MnMachinePrecision:
@@ -2479,7 +2466,7 @@ class Minuit:
             pr.eps = self._precision
         return pr
 
-    def _normalize_key(self, key: Union[int, str]) -> Tuple[int, str]:
+    def _normalize_key(self, key: int | str) -> tuple[int, str]:
         if isinstance(key, int):
             if key >= self.npar:
                 raise ValueError(f"parameter {key} is out of range (max: {self.npar})")
@@ -2489,8 +2476,8 @@ class Minuit:
         return self._var2pos[key], key
 
     def _normalize_bound(
-        self, vname: str, bound: Union[float, UserBound, Tuple[float, float]]
-    ) -> Tuple[float, float]:
+        self, vname: str, bound: float | UserBound | tuple[float, float]
+    ) -> tuple[float, float]:
         if isinstance(bound, Iterable):
             return mutil._normalize_limit(bound)
 
@@ -2637,7 +2624,7 @@ class Minuit:
         ncall: int,
         iterate: int,
         use_simplex: bool,
-    ) -> List[Tuple[float, float]]:
+    ) -> list[tuple[float, float]]:
         from scipy.optimize import root_scalar
 
         center = self.values[[ix, iy]]
@@ -2713,7 +2700,7 @@ class Minuit:
 
 
 def _make_init_state(
-    pos2var: Tuple[str, ...], args: np.ndarray, kwds: Dict[str, float]
+    pos2var: tuple[str, ...], args: np.ndarray, kwds: dict[str, float]
 ) -> MnUserParameterState:
     nargs = len(args)
     # check kwds
@@ -2745,7 +2732,7 @@ def _make_init_state(
 
 
 def _get_params(mps: MnUserParameterState, merrors: mutil.MErrors) -> mutil.Params:
-    def get_me(name: str) -> Optional[Tuple[float, float]]:
+    def get_me(name: str) -> tuple[float, float] | None:
         if name in merrors:
             me = merrors[name]
             return me.lower, me.upper
@@ -2850,7 +2837,7 @@ def _robust_low_level_fit(
     ncall: int,
     strategy: MnStrategy,
     tolerance: float,
-    precision: Optional[float],
+    precision: float | None,
     iterate: int,
     use_simplex: bool,
 ) -> FunctionMinimum:

--- a/src/iminuit/pdg_format.py
+++ b/src/iminuit/pdg_format.py
@@ -47,7 +47,6 @@ https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 """
 
 import math
-from typing import List
 
 
 term = (" %s", " +%s", " ± %s", " (%s)", "(%s)E%+03i", True, None)
@@ -162,7 +161,7 @@ def pdg_format(value, error, *errors, labels=None, format=term, leader=None, exp
         return fmt_sc % (s, nexp)
 
 
-def _strip(items: List[str]) -> List[str]:
+def _strip(items: list[str]) -> list[str]:
     assert all("e" not in x for x in items)
     # ignore inf and nan
     mask = tuple(i for (i, s) in enumerate(items) if "." in s)

--- a/src/iminuit/qtwidget.py
+++ b/src/iminuit/qtwidget.py
@@ -3,7 +3,8 @@
 from .util import _widget_guess_initial_step, _make_finite
 import warnings
 import numpy as np
-from typing import Dict, Any, Callable
+from collections.abc import Callable
+from typing import Any
 from contextlib import contextmanager
 
 try:
@@ -21,7 +22,7 @@ except ModuleNotFoundError as e:
 def make_widget(
     minuit: Any,
     plot: Callable[..., None],
-    kwargs: Dict[str, Any],
+    kwargs: dict[str, Any],
     raise_on_exception: bool,
     run_event_loop: bool = True,
 ):

--- a/src/iminuit/typing.py
+++ b/src/iminuit/typing.py
@@ -4,11 +4,10 @@ Types for iminuit.
 These are used by mypy and similar tools.
 """
 
+from __future__ import annotations
+
 from typing import (
     Protocol,
-    Optional,
-    List,
-    Union,
     runtime_checkable,
     NamedTuple,
     Annotated,
@@ -18,7 +17,7 @@ import numpy as np
 import dataclasses
 
 # Key for ValueView, ErrorView, etc.
-Key = Union[int, str, slice, List[Union[int, str]]]
+Key = int | str | slice | list[int | str]
 
 
 @runtime_checkable
@@ -73,8 +72,8 @@ class LossFunction(Protocol):
 class UserBound(NamedTuple):
     """Type for user-defined limit."""
 
-    min: Optional[float]
-    max: Optional[float]
+    min: float | None
+    max: float | None
 
 
 @dataclasses.dataclass
@@ -109,10 +108,10 @@ class Le:
 class Interval:
     """Annotation compatible with annotated-types."""
 
-    gt: Optional[float] = None
-    ge: Optional[float] = None
-    lt: Optional[float] = None
-    le: Optional[float] = None
+    gt: float | None = None
+    ge: float | None = None
+    lt: float | None = None
+    le: float | None = None
 
 
 # common convenience types

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -16,22 +16,16 @@ from numpy.typing import NDArray, ArrayLike
 from typing import (
     overload,
     Any,
-    List,
     Union,
     Dict,
-    Iterable,
-    Generator,
     Tuple,
-    Optional,
-    Callable,
-    Collection,
-    Sequence,
     TypeVar,
     Annotated,
     SupportsIndex,
     get_args,
     get_origin,
 )
+from collections.abc import Iterable, Generator, Callable, Collection, Sequence
 import abc
 from time import monotonic
 import warnings
@@ -144,7 +138,7 @@ class BasicView(abc.ABC):
         s += ">"
         return s
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> dict[str, float]:
         """Obtain dict representation."""
         return {k: self._get(i) for i, k in enumerate(self._minuit._pos2var)}
 
@@ -211,9 +205,9 @@ class LimitView(BasicView):
 
     def __init__(self, minuit: Any):
         # Users should not call this __init__, instances are created by the library
-        super(LimitView, self).__init__(minuit, 1)
+        super().__init__(minuit, 1)
 
-    def _get(self, idx: int) -> Tuple[float, float]:
+    def _get(self, idx: int) -> tuple[float, float]:
         p = self._minuit._last_state[idx]
         return (
             p.lower_limit if p.has_lower_limit else -np.inf,
@@ -245,7 +239,7 @@ class LimitView(BasicView):
         state.set_error(idx, err)
 
 
-def _normalize_limit(lim: Optional[Iterable]) -> Tuple[float, float]:
+def _normalize_limit(lim: Iterable | None) -> tuple[float, float]:
     if lim is None:
         return (-np.inf, np.inf)
     a, b = lim
@@ -285,13 +279,13 @@ class Matrix(np.ndarray):
     def __array_finalize__(self, obj: Any) -> None:
         """For internal use."""
         if obj is None:
-            self._var2pos: Dict[str, int] = {}
+            self._var2pos: dict[str, int] = {}
         else:
             self._var2pos = getattr(obj, "_var2pos", {})
 
     def __getitem__(  # type:ignore
         self,
-        key: Union[Key, Tuple[Key, Key], Iterable[Key], NDArray],
+        key: Key | tuple[Key, Key] | Iterable[Key] | NDArray,
     ) -> NDArray:
         """Get matrix element at key."""
         var2pos = self._var2pos
@@ -318,7 +312,7 @@ class Matrix(np.ndarray):
             return np.ndarray.__getitem__(t, index2).T  # type:ignore
         return super().__getitem__(key)
 
-    def to_dict(self) -> Dict[Tuple[str, str], float]:
+    def to_dict(self) -> dict[tuple[str, str], float]:
         """
         Convert matrix to dict.
 
@@ -333,7 +327,7 @@ class Matrix(np.ndarray):
                 d[pi, pj] = float(self[i, j])
         return d
 
-    def to_table(self) -> Tuple[List[List[str]], Tuple[str, ...]]:
+    def to_table(self) -> tuple[list[list[str]], tuple[str, ...]]:
         """
         Convert matrix to tabular format.
 
@@ -373,7 +367,7 @@ class Matrix(np.ndarray):
 
     def __repr__(self):
         """Get detailed text representation."""
-        return super(Matrix, self).__str__()
+        return super().__str__()
 
     def __str__(self):
         """Get user-friendly text representation."""
@@ -718,11 +712,11 @@ class Param:
     name: str
     value: float
     error: float
-    merror: Optional[Tuple[float, float]]
+    merror: tuple[float, float] | None
     is_const: bool
     is_fixed: bool
-    lower_limit: Optional[float]
-    upper_limit: Optional[float]
+    lower_limit: float | None
+    upper_limit: float | None
 
     def __repr__(self) -> str:
         """Get detailed text representation."""
@@ -765,7 +759,7 @@ class Params(tuple):
     def _repr_html_(self) -> str:
         return _repr_html.params(self)
 
-    def to_table(self) -> Tuple[List[List[str]], List[str]]:
+    def to_table(self) -> tuple[list[list[str]], list[str]]:
         """
         Convert parameter data to a tabular format.
 
@@ -838,7 +832,7 @@ class Params(tuple):
                     key = i
                     break
         assert isinstance(key, (int, slice))
-        return super(Params, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def __str__(self) -> str:
         """Get user-friendly text representation."""
@@ -950,7 +944,7 @@ class MErrors(OrderedDict):
         else:
             p.text(str(self))
 
-    def __getitem__(self, key: Union[int, str]) -> MError:
+    def __getitem__(self, key: int | str) -> MError:
         """Get item at key, which can be an index or a parameter name."""
         if isinstance(key, int):
             if key < 0:
@@ -970,7 +964,7 @@ def propagate(
     fn: Callable,
     x: Collection[float],
     cov: Collection[Collection[float]],
-) -> Tuple[NDArray, NDArray]:
+) -> tuple[NDArray, NDArray]:
     """
     Numerically propagates the covariance into a new space.
 
@@ -1082,7 +1076,7 @@ def make_with_signature(
 
 def merge_signatures(
     callables: Iterable[Callable], annotations: bool = False
-) -> Tuple[Any, List[List[int]]]:
+) -> tuple[Any, list[list[int]]]:
     """
     Merge signatures of callables with positional arguments.
 
@@ -1111,8 +1105,8 @@ def merge_signatures(
         mapping contains the mapping of parameters indices from the merged signature to
         the original signatures.
     """
-    args: List[str] = []
-    anns: List[Optional[Tuple[float, float]]] = []
+    args: list[str] = []
+    anns: list[tuple[float, float] | None] = []
     mapping = []
 
     for f in callables:
@@ -1132,13 +1126,13 @@ def merge_signatures(
 
 
 @overload
-def describe(callable: Callable) -> List[str]: ...  # pragma: no cover
+def describe(callable: Callable) -> list[str]: ...  # pragma: no cover
 
 
 @overload
 def describe(
     callable: Callable, *, annotations: bool
-) -> Dict[str, Optional[Tuple[float, float]]]: ...  # pragma: no cover
+) -> dict[str, tuple[float, float] | None]: ...  # pragma: no cover
 
 
 def describe(callable, *, annotations=False):
@@ -1354,8 +1348,8 @@ def _describe_impl_docstring(callable):
 
 
 def _get_limit(
-    annotation: Union[type, Annotated[float, Any], str],
-) -> Optional[Tuple[float, float]]:
+    annotation: type | Annotated[float, Any] | str,
+) -> tuple[float, float] | None:
     from iminuit import typing
 
     if isinstance(annotation, str):
@@ -1415,14 +1409,14 @@ def _guess_initial_step(val: float) -> float:
     return 1e-2 * abs(val) if val != 0 else 1e-1  # heuristic
 
 
-def _key2index_from_slice(var2pos: Dict[str, int], key: slice) -> List[int]:
+def _key2index_from_slice(var2pos: dict[str, int], key: slice) -> list[int]:
     start = var2pos[key.start] if isinstance(key.start, str) else key.start
     stop = var2pos[key.stop] if isinstance(key.stop, str) else key.stop
     start, stop, step = slice(start, stop, key.step).indices(len(var2pos))
     return list(range(start, stop, step))
 
 
-def _key2index_item(var2pos: Dict[str, int], key: Union[str, int]) -> int:
+def _key2index_item(var2pos: dict[str, int], key: str | int) -> int:
     if isinstance(key, str):
         return var2pos[key]
     i = key
@@ -1434,9 +1428,9 @@ def _key2index_item(var2pos: Dict[str, int], key: Union[str, int]) -> int:
 
 
 def _key2index(
-    var2pos: Dict[str, int],
+    var2pos: dict[str, int],
     key: Key,
-) -> Union[int, List[int]]:
+) -> int | list[int]:
     if key is ...:
         return list(range(len(var2pos)))
     if isinstance(key, slice):
@@ -1475,7 +1469,7 @@ def _iterate(x):
             yield xi
 
 
-def _replace_none(x: Optional[T], v: T) -> T:
+def _replace_none(x: T | None, v: T) -> T:
     if x is None:
         return v
     return x
@@ -1638,7 +1632,7 @@ def _detect_log_spacing(x: NDArray) -> bool:
     return bool(log_rel_std < lin_rel_std)
 
 
-def gradient(fcn: Cost) -> Optional[CostVector]:
+def gradient(fcn: Cost) -> CostVector | None:
     """
     Return a callable which computes the gradient of fcn or None.
 
@@ -1663,7 +1657,7 @@ def gradient(fcn: Cost) -> Optional[CostVector]:
     return _cost_extra_impl(fcn, "grad")
 
 
-def g2(fcn: Cost) -> Optional[CostVector]:
+def g2(fcn: Cost) -> CostVector | None:
     """
     Return a callable which computes the diagonal of the Hessian of fcn or None.
 
@@ -1688,7 +1682,7 @@ def g2(fcn: Cost) -> Optional[CostVector]:
     return _cost_extra_impl(fcn, "g2")
 
 
-def hessian(fcn: Cost) -> Optional[CostVector]:
+def hessian(fcn: Cost) -> CostVector | None:
     """
     Return a callable which computes the Hessian matrix of fcn or None.
 
@@ -1713,7 +1707,7 @@ def hessian(fcn: Cost) -> Optional[CostVector]:
     return _cost_extra_impl(fcn, "hessian")
 
 
-def _cost_extra_impl(fcn: Cost, kind: str) -> Optional[CostVector]:
+def _cost_extra_impl(fcn: Cost, kind: str) -> CostVector | None:
     aux = getattr(fcn, kind, None)
     has_aux = getattr(fcn, f"has_{kind}", True)
     if aux and isinstance(aux, CostVector) and has_aux:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses part of #1132.

Python 3.9 reached EOL in October 2025. This PR drops 3.9 support, bumping the minimum to Python 3.10, and applies the modernizations that unlocks.

## Changes

**pyproject.toml**
- `requires-python = ">=3.10"` (was `>=3.9`)
- `numpy >=1.21.3` (oldest numpy with a 3.10 wheel; was `>=1.21`)
- Added explicit `Programming Language :: Python :: 3.10/3.11/3.12/3.13` classifiers
- `[tool.cibuildwheel]`: removed `cp39-musllinux_i686` skip entry (replaced with `cp310-musllinux_i686`)
- `[[tool.cibuildwheel.overrides]]`: selector changed from `cp3{9,10}-manylinux*` to `cp310-manylinux*`

**.github/workflows/release.yml**
- Removed `cp39` from the `py:` matrix
- Removed two cp39 excludes (ubuntu-24.04-arm and windows-11-arm)

**.github/workflows/test.yml**
- Minimum-version test leg updated from `python-version: "3.9"` / `numpy==1.21.0` to `python-version: "3.10"` / `numpy==1.21.3`

**noxfile.py**
- No changes needed: `MINIMUM_PYTHON` reads from `pyproject.toml` dynamically, so it picks up 3.10 automatically.

**Typing modernization (src/iminuit/)**
- `typing.py`: removed `Optional`, `Union`, `List` imports; `Key` type alias and `UserBound`/`Interval` fields now use `X | Y` and `float | None` syntax; added `from __future__ import annotations`
- `ipywidget.py`, `qtwidget.py`: `from typing import Dict, Callable` replaced with `collections.abc.Callable` and `dict[str, Any]`
- Ruff UP auto-fixes applied across src/ (213 fixes): deprecated `typing.Union`, `Optional`, `List`, `Tuple`, `Dict`, `Set` usages replaced with modern equivalents in `minuit.py`, `cost.py`, `util.py`, `_deprecated.py`, `_optional_dependencies.py`, `_parse_version.py`, `_repr_html.py`; unused typing imports removed (F401)
- One correctness fix in `minuit.py`: `method: str | Callable | None = None` (ruff correctly surfaced a latent mypy issue)

**doc/conf.py**
- Synced `root_version` to match the submodule SHA (pre-commit hook was failing on a pre-existing mismatch)

## Test results

All tests pass on Python 3.10 except `tests/test_tabulate.py::test_params` which is a **pre-existing failure** on the develop branch (tabulate column-alignment difference unrelated to this PR).

## Note on conflicts

This PR modifies `minuit.py`, `cost.py`, and `util.py` (import blocks only, not logic). It may conflict slightly with parallel bugfix PRs touching those same files. Recommend merging this PR last among active PRs, or rebasing it on top of them once they land.