### PR TITLE
fix: masked BinnedNLL gradient

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -2022,7 +2022,7 @@ class BinnedNLL(BinnedCostWithModel):
         # normalise probability of remaining bins
         if ma is not None:
             psum = np.sum(p[ma])
-            pg = pg / psum - p * np.sum(pg[:, ma]) / psum**2
+            pg = pg / psum - p * np.sum(pg[:, ma], axis=1)[:, np.newaxis] / psum**2
             p /= psum
         # scale probabilities with total number of entries of unmasked bins in histogram
         n = self._counts()

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -2022,7 +2022,10 @@ class BinnedNLL(BinnedCostWithModel):
         # normalise probability of remaining bins
         if ma is not None:
             psum = np.sum(p[ma])
-            pg = pg / psum - p * np.sum(pg[:, ma], axis=1)[:, np.newaxis] / psum**2
+            # sum over all bin axes; pg[:, ma] keeps the trailing axes of a
+            # multi-dimensional histogram, so it needs a reshape to broadcast over p
+            corr = np.sum(pg[:, ma].reshape(len(pg), -1), axis=1)
+            pg = pg / psum - p * corr.reshape((-1,) + (1,) * p.ndim) / psum**2
             p /= psum
         # scale probabilities with total number of entries of unmasked bins in histogram
         n = self._counts()

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -904,6 +904,27 @@ def test_BinnedNLL_mask_grad_multipar():
         assert_allclose(g, ref(*args), rtol=1e-3)
 
 
+def test_BinnedNLL_2D_mask_grad():
+    # regression test: with a multi-dimensional histogram, the mask selects along
+    # the first axis only, so the correction must sum over the remaining axes too
+    pytest.importorskip("jacobi")
+    truth = (0.1, 0.2, 0.9, 1.1)
+    x, y = mvnorm(*truth).rvs(size=1000, random_state=1).T
+    w, xe, ye = np.histogram2d(x, y, bins=(6, 5))
+
+    def model(xy, mux, muy, sx, sy):
+        return mvnorm(mux, muy, sx, sy).cdf(xy.T)
+
+    c = BinnedNLL(w, (xe, ye), model, grad=numerical_model_gradient(model))
+    c.mask = np.arange(len(w)) != 2
+
+    ref = numerical_cost_gradient(c)
+    args = (0.0, 0.1, 1.0, 1.0)
+    g = c.grad(*args)
+    assert np.linalg.norm(g) > 1.0
+    assert_allclose(g, ref(*args), rtol=1e-3)
+
+
 def test_BinnedNLL_properties():
     def cdf(x, a, b):
         return 0

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -887,6 +887,23 @@ def test_BinnedNLL_mask():
     assert_allclose(c.grad(2), ref(2))
 
 
+def test_BinnedNLL_mask_grad_multipar():
+    # regression test: the masked gradient renormalization correction must be
+    # per-parameter; with >=2 parameters a scalar correction is wrong
+    pytest.importorskip("jacobi")
+    xe = np.linspace(-2, 2, 6)
+    n = np.diff(norm_cdf(xe, 0.1, 1.2)) * 1000
+    c = BinnedNLL(n, xe, norm_cdf, grad=numerical_model_gradient(norm_cdf))
+    c.mask = np.arange(len(n)) != 2
+
+    ref = numerical_cost_gradient(c)
+    # evaluate away from the truth so the gradient is clearly non-zero
+    for args in [(0.0, 1.0), (0.3, 0.8), (-0.2, 1.5)]:
+        g = c.grad(*args)
+        assert np.linalg.norm(g) > 1.0
+        assert_allclose(g, ref(*args), rtol=1e-3)
+
+
 def test_BinnedNLL_properties():
     def cdf(x, a, b):
         return 0


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The masked renormalization correction in `BinnedNLL._grad` summed the model gradient over both axes, which gave one scalar for all parameters. It must give one correction per parameter. Any masked `BinnedNLL` fit that used the analytic gradient got silently wrong results.

The mask selects along the first axis only, so for a multi-dimensional histogram the correction must also sum over the remaining bin axes, then reshape to broadcast over the prediction.

The existing `test_BinnedNLL_mask` uses a one-parameter 1D model, for which the sums agree, so the bug was not seen. The new tests compare against a numerical gradient with two parameters in 1D and with a masked 2D histogram.

Reported in #1132.