### PR TITLE
fix: fixto and reset did not handle Minuit state correctly

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -792,6 +792,7 @@ class Minuit:
                 for i, v in zip(index, value):
                     self.fixto(i, v)
         else:
+            self._copy_state_if_needed()
             self._last_state.fix(index)
             self._last_state.set_value(index, value)
         return self  # return self for method chaining
@@ -807,6 +808,8 @@ class Minuit:
         self._fmin = None
         self._fcn._nfcn = 0
         self._fcn._ngrad = 0
+        self._fcn._ng2 = 0
+        self._fcn._nhessian = 0
         self._merrors = mutil.MErrors()
         self._covariance: mutil.Matrix = None
         return self  # return self for method chaining and to autodisplay current state

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1876,3 +1876,39 @@ def test_mncontour_experimental_per_param_limits():
     cont0 = m.mncontour(0, 1, size=30, experimental=False)
     assert np.all(cont0[:, 0] >= -0.3 - 1e-9)
     assert np.all(cont0[:, 1] <= 0.3 + 1e-9)
+
+
+def test_fixto_does_not_mutate_fmin():
+    # fixto after migrad must not mutate the (immutable) FunctionMinimum state
+    m = Minuit(func0, x=0, y=0)
+    m.migrad()
+    values_before = [p.value for p in m.fmin._src.state]
+
+    # before fixto, _last_state is a reference to the FunctionMinimum's state
+    assert not m._fmin_does_not_exist_or_last_state_was_modified()
+
+    m.fixto("x", 1.0)
+
+    # the stored FunctionMinimum must be unchanged
+    values_after = [p.value for p in m.fmin._src.state]
+    assert values_after == values_before
+    assert values_before[0] != 1.0
+
+    # fixto modified _last_state, so the next hesse must rebuild from a seed
+    assert m._fmin_does_not_exist_or_last_state_was_modified()
+
+
+def test_reset_resets_all_counters():
+    m = Minuit(func0, grad=func0_grad, x=0, y=0)
+    m.migrad()
+    # all four FCN counters are reset, including _ng2 and _nhessian which
+    # reset() previously left untouched
+    m._fcn._ng2 = 7
+    m._fcn._nhessian = 3
+    assert m._fcn._nfcn > 0
+    assert m._fcn._ngrad > 0
+    m.reset()
+    assert m._fcn._nfcn == 0
+    assert m._fcn._ngrad == 0
+    assert m._fcn._ng2 == 0
+    assert m._fcn._nhessian == 0


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit.fixto` changed `_last_state` directly. After a fit, `_last_state` is the state of the stored `FunctionMinimum`, so `fixto` also changed the recorded minimum. The fix calls `_copy_state_if_needed()` first, like the other state setters do.

`Minuit.reset` set only the `_nfcn` and `_ngrad` counters to zero. The `_ng2` and `_nhessian` counters kept their old values. The fix resets all four.

The other fixes from the first version of this PR are now in separate pull requests. Part of #1132.