### PR TITLE
fix: repair CI (tabulate test, notebook FCN return type)

### DIFF
--- a/src/fcn.cpp
+++ b/src/fcn.cpp
@@ -42,6 +42,27 @@ FCN::FCN(py::object fcn, py::object grad, py::object g2, py::object hessian,
   }
 }
 
+// Convert the value returned by the Python cost function into a double.
+//
+// In addition to plain Python floats/ints, this accepts numpy scalars and
+// numpy arrays of size 1 (0-d or shape (1,)). Older numpy versions allowed
+// such arrays to be converted implicitly via float(), but numpy >= 2 raises
+// for arrays with ndim > 0, which silently broke user cost functions that
+// return e.g. ``np.diff(...)``. We restore the previous behavior by calling
+// ``.item()`` on numpy arrays, which works for any size-1 array and raises a
+// clear error otherwise.
+double as_double(py::handle obj) {
+  if (py::isinstance<py::array>(obj)) {
+    auto arr = py::reinterpret_borrow<py::array>(obj);
+    if (arr.size() != 1)
+      throw std::runtime_error(
+          "cost function must return a scalar, but returned an array of size " +
+          std::to_string(arr.size()));
+    return py::cast<double>(arr.attr("item")());
+  }
+  return py::cast<double>(obj);
+}
+
 double FCN::operator()(const std::vector<double>& x) const {
   ++nfcn_;
   if (array_call_) {
@@ -49,10 +70,10 @@ double FCN::operator()(const std::vector<double>& x) const {
       return cfcn_(x.size(), x.data());
     } else {
       py::array_t<double> a(static_cast<py::ssize_t>(x.size()), x.data());
-      return check_value(py::cast<double>(fcn_(a)), x);
+      return check_value(as_double(fcn_(a)), x);
     }
   }
-  return check_value(py::cast<double>(fcn_(*py::cast(x))), x);
+  return check_value(as_double(fcn_(*py::cast(x))), x);
 }
 
 std::vector<double> FCN::Gradient(const std::vector<double>& x) const {

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -366,6 +366,25 @@ def test_wrong_use_of_array_init():
         m.migrad()
 
 
+@pytest.mark.parametrize(
+    "wrap", [lambda v: np.array(v), lambda v: np.array([v]), lambda v: np.float64(v)]
+)
+def test_cost_returns_size_one_array(wrap):
+    # cost functions that return a numpy scalar or a size-1 array (0-d or
+    # shape (1,)) must be accepted; numpy >= 2 no longer converts size-1
+    # arrays via float(), which used to silently break such functions.
+    m = Minuit(lambda x, y: wrap(x**2 + (y - 1) ** 2), x=1, y=0)
+    m.migrad()
+    assert m.valid
+    assert_allclose(m.values, (0, 1), atol=1e-3)
+
+
+def test_cost_returns_wrong_size_array():
+    m = Minuit(lambda x: np.array([x, x]), x=1)
+    with pytest.raises(RuntimeError, match="must return a scalar"):
+        m.migrad()
+
+
 def test_reset():
     m = Minuit(func0, x=0, y=0)
     m.migrad()

--- a/tests/test_tabulate.py
+++ b/tests/test_tabulate.py
@@ -17,10 +17,10 @@ def test_params():
     assert (
         framed(tab.tabulate(*m.params.to_table()))
         == """
-  pos  name      value    error  error-    error+    limit-    limit+    fixed
+  pos  name      value    error    error-    error+    limit-    limit+  fixed
 -----  ------  -------  -------  --------  --------  --------  --------  -------
     0  x             0      0.1                                          yes
-    1  y             0      1.5  -1.0      1.0       -1.0      1.0
+    1  y             0      1.5        -1         1        -1         1
 """
     )
 


### PR DESCRIPTION
Okay, looks good to me. Who needs to approve PRs currently? @HDembinski, you, me, someone else?

:robot: _AI text below_ :robot:

CI has been broken on `develop` itself (not caused by recent PRs) due to two unrelated upstream dependency changes. This fixes both so the Coverage and Docs checks failing on the PRs for #1132 are unblocked.

## Failure 1: Coverage workflow — `tests/test_tabulate.py::test_params`

**Root cause:** `tabulate` **0.10.0** changed its output formatting: it right-aligns/pads columns differently and renders integer-valued floats like `-1.0`/`1.0` as `-1`/`1`. The test hardcodes the rendered table string, so it no longer matched.

This is purely a `tabulate` rendering change, **not** a library bug. `Minuit.params.to_table()` is unchanged and still emits the string `"-1.0"`; `tabulate` re-parses that string and reformats it. Verified by inspecting the raw `to_table()` output (still `[..., -1.0, 1.0, ...]`).

**Fix:** updated the expected string in the test to the current `tabulate` output. No version pin is added (the test extra already depends on plain `tabulate`); this test only exists to exercise `to_table()` interop.

## Failure 2: Docs workflow — notebook execution `RuntimeError`

`doc/notebooks/scipy_and_constraints.ipynb` failed inside the C++ migrad call with:

```
RuntimeError: Unable to cast Python instance of type <class numpy.ndarray> to C++ type double
```

**Root cause:** the notebook's cost function (`ExtendedUnbinnedNLL` with a `model` whose first return is `np.diff(bernstein.integral(...))`) returns a **shape-`(1,)` numpy array**. `src/fcn.cpp` cast the FCN return value to `double` via `py::cast<double>`, which relied on numpy implicitly converting a size-1 array through `float()`. **numpy >= 2** (here numpy 2.4.6) raises `only 0-dimensional arrays can be converted to Python scalars` for any array with `ndim > 0`, so size-1 (shape `(1,)`) returns that used to be accepted now fail. This is user-facing API that silently broke.

**Fix (chosen over editing the notebook):** the robust fix is in the binding, since accepting size-1/0-d numpy returns from cost functions is established user-facing behavior. Added an `as_double()` helper in `src/fcn.cpp` that, for numpy arrays, requires size 1 and converts via `.item()` (works for 0-d arrays, shape-`(1,)` arrays, and numpy scalars), and raises a clear error (`cost function must return a scalar, but returned an array of size N`) otherwise. Plain Python floats/ints take the original fast path unchanged.

Added regression tests in `tests/test_minuit.py`:
- `test_cost_returns_size_one_array` — cost returning `np.array(v)` (0-d), `np.array([v])` (shape `(1,)`), and `np.float64(v)`.
- `test_cost_returns_wrong_size_array` — cost returning a 2-element array raises the new clear error.

## Verification
- Full test suite: `uv run pytest -n=auto -q` passes (only the usual float128/jax skips).
- Lint: `prek -a --quiet` clean on touched files (the pre-existing `check-root-version` failure is unrelated, being fixed in #1135).
- `doc/notebooks/scipy_and_constraints.ipynb` re-executed end-to-end via `nbconvert --execute` successfully; full `nox -s doc` build run as final verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)