### PR TITLE
fix: matplotlib >= 3.11 figure reuse in CostSum.visualize (repairs coverage CI)

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -767,7 +767,7 @@ class CostSum(Cost, ABCSequence):
 
         fig = plt.gcf()
         fig.set_figwidth(n * fig.get_figwidth() / 1.5)
-        _, ax = plt.subplots(1, n, num=fig.number)
+        _, ax = plt.subplots(1, n, num=fig.number, clear=True)
 
         if component_kwargs is None:
             component_kwargs = {}


### PR DESCRIPTION
matplotlib 3.11 raises when `plt.subplots(num=...)` is given an existing figure number. `CostSum.visualize` grabs the current figure with `plt.gcf()` and then calls `plt.subplots(1, n, num=fig.number)`, hitting this error:

```
ValueError: Figure 1 already exists. Use plt.figure(1) to get it or plt.close(1)
to close it. Alternatively, pass 'clear=True' to subplots().
```

One line fix. CI has been red (and iminuit has been broken) since June 11.