### PR TITLE
ci: drop 3.13t (keep 3.14t), update intel macOS image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest, ubuntu-24.04-arm, windows-11-arm]
-        py: [cp39, cp310, cp311, cp312, cp313, cp313t, cp314, cp314t]
+        py: [cp39, cp310, cp311, cp312, cp313, cp314, cp314t]
         exclude:
           - os: ubuntu-24.04-arm
             py: cp39

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest, ubuntu-24.04-arm, windows-11-arm]
+        os: [ubuntu-latest, windows-latest, macos-26-intel, macos-latest, ubuntu-24.04-arm, windows-11-arm]
         py: [cp39, cp310, cp311, cp312, cp313, cp314, cp314t]
         exclude:
           - os: ubuntu-24.04-arm


### PR DESCRIPTION
cibuildwheel/manylinux has dropped 3.13t (which was experimental only), pybind11 is dropping 3.13t, numpy dropped it, etc, so drop it here too. Support 3.14t+ only.

GitHub has also removed the `macos-13` runner, so the x86-64 macOS wheel jobs now queue forever. Switch them to `macos-26-intel`.

This fixes the CI on jobs that touch files triggering wheel builds.

Part of unblocking #1143.

:robot: _AI text below_ :robot:

NumPy no longer ships free-threaded (`cp313t`) wheels for Windows `win32` and `win_arm64`. cibuildwheel then tries to build numpy from source in the wheel test step and fails (no compiler / `Python.h`). The `cp313t` Windows jobs are red on any PR that triggers the wheel matrix (e.g. #1133, #1135).

Free-threaded 3.14 (`cp314t`) wheels exist and already pass across the whole matrix, so this drops `cp313t` from the wheel build matrix in `release.yml` and keeps `cp314t`.