### PR TITLE
fix: mask handling in BinnedCost._n_err and LeastSquares._pulls

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -861,7 +861,8 @@ class MaskedCostWithPulls(MaskedCost):
         -------
         array
             Array of pull values. If the cost function is masked, the array contains NaN
-            values where the mask value is False.
+            values where the mask value is False. Data points with zero error also
+            yield NaN.
 
         Notes
         -----

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -179,6 +179,16 @@ def _replace_none(x, replacement):
     return x
 
 
+def _exclusion_from_mask(mask: NDArray, n: int) -> NDArray:
+    # Return a boolean array of length n that is True for excluded entries.
+    # mask may be a boolean array or an array of indices of selected entries.
+    if mask.dtype == bool:
+        return ~mask
+    excluded = np.ones(n, dtype=bool)
+    excluded[mask] = False
+    return excluded
+
+
 def chi2(y: ArrayLike, ye: ArrayLike, ym: ArrayLike) -> float:
     """
     Compute (potentially) chi2-distributed cost.
@@ -1436,7 +1446,11 @@ class BinnedCost(MaskedCostWithPulls):
         # mask values where error is zero
         ma = err == 0
         if self.mask is not None:
-            ma = ~self.mask
+            # the mask acts on the first dimension; broadcast the per-bin
+            # exclusion across the remaining dimensions before combining
+            excluded = _exclusion_from_mask(self.mask, n.shape[0])
+            excluded = excluded.reshape((-1,) + (1,) * (n.ndim - 1))
+            ma = ma | excluded
         n[ma] = np.nan
         err[ma] = np.nan
         return n, err
@@ -2351,10 +2365,11 @@ class LeastSquares(MaskedCostWithPulls):
         ye = self.yerror.copy()
         ym = self.prediction(args)
 
+        ma = ye == 0
         if self.mask is not None:
-            ma = ~self.mask
-            y[ma] = np.nan
-            ye[ma] = np.nan
+            ma = ma | _exclusion_from_mask(self.mask, y.shape[0])
+        y[ma] = np.nan
+        ye[ma] = np.nan
         return (y - ym) / ye
 
     def _pred(self, args: Sequence[float]) -> NDArray:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -681,6 +681,14 @@ def test_BinnedNLL_pulls_mask():
     assert np.isnan(p2[2])
     assert_allclose(p2[[0, 1, 3]], p[[0, 1, 3]])
 
+    # a zero-count bin has zero error and must give NaN in addition to the mask
+    c = BinnedNLL([5, 0, 50, 1], xe, expon_cdf)
+    c.mask = np.array([True, True, False, True])
+    p = c.pulls(args)
+    assert np.isnan(p[1])
+    assert np.isnan(p[2])
+    assert not np.any(np.isnan(p[[0, 3]]))
+
 
 @pytest.mark.parametrize("use_grad", (False, True))
 def test_BinnedNLL_weighted(use_grad):
@@ -1505,8 +1513,7 @@ def test_LeastSquares_pulls_mask_index():
 
 
 def test_LeastSquares_pulls_zero_error():
-    # bins with zero error must yield NaN pulls (documented), not +-inf,
-    # also when inside the user mask
+    # bins with zero error must yield NaN pulls, not +-inf, with or without a mask
     c = LeastSquares([1, 2, 3], [2, 3, 4], [0.1, 0.0, 0.1], line)
     p = c.pulls((0, 1))
     assert_equal(p, [10, np.nan, 10])

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -658,6 +658,30 @@ def test_BinnedNLL_pulls(binned):
     assert np.nanvar(pulls) == pytest.approx(1, abs=0.2)
 
 
+def test_BinnedNLL_pulls_mask():
+    # masked bins must produce NaN pulls for both boolean and index masks
+    n = np.array([5, 1000, 50, 1])
+    xe = [0, 1, 2, 3, 4]
+    c = BinnedNLL(n, xe, expon_cdf)
+    args = (1.0,)
+
+    full = c.pulls(args)
+    assert not np.any(np.isnan(full))
+
+    # boolean mask: masked bin is NaN, the rest finite
+    c.mask = np.array([True, True, False, True])
+    p = c.pulls(args)
+    assert np.isnan(p[2])
+    assert not np.any(np.isnan(p[[0, 1, 3]]))
+
+    # index mask selecting the same bins must give identical pulls;
+    # bitwise NOT of an index array would poison the wrong bins
+    c.mask = np.array([0, 1, 3])
+    p2 = c.pulls(args)
+    assert np.isnan(p2[2])
+    assert_allclose(p2[[0, 1, 3]], p[[0, 1, 3]])
+
+
 @pytest.mark.parametrize("use_grad", (False, True))
 def test_BinnedNLL_weighted(use_grad):
     xe = np.array([0, 0.2, 0.4, 0.8, 1.5, 10])
@@ -1470,6 +1494,25 @@ def test_LeastSquares_pulls():
     assert_equal(c.pulls((0, 1)), [10, 10])
     c.mask = [True, False]
     assert_equal(c.pulls((0, 1)), [10, np.nan])
+
+
+def test_LeastSquares_pulls_mask_index():
+    # an index mask must mask the same bins as the equivalent boolean mask;
+    # bitwise NOT of an index array would poison the wrong bins
+    c = LeastSquares([1, 2, 3], [2, 3, 4], 0.1, line)
+    c.mask = [0, 2]
+    assert_equal(c.pulls((0, 1)), [10, np.nan, 10])
+
+
+def test_LeastSquares_pulls_zero_error():
+    # bins with zero error must yield NaN pulls (documented), not +-inf,
+    # also when inside the user mask
+    c = LeastSquares([1, 2, 3], [2, 3, 4], [0.1, 0.0, 0.1], line)
+    p = c.pulls((0, 1))
+    assert_equal(p, [10, np.nan, 10])
+    c.mask = [True, True, True]
+    p = c.pulls((0, 1))
+    assert_equal(p, [10, np.nan, 10])
 
 
 @pytest.mark.parametrize("use_grad", (False, True))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two bugs in the pull computation, split out of #1137.

- An index-array mask was negated with `~`, which is bitwise NOT for integers, so the wrong bins became NaN. The new helper `_exclusion_from_mask` handles boolean masks and index masks.
- The user mask replaced the `err == 0` mask instead of combining with it, so bins with zero error gave ±inf pulls instead of NaN. `LeastSquares.pulls` now also gives NaN for zero-error points when no mask is set (before: ±inf), consistent with `BinnedCost`. The `pulls` docstring now states this.

Reported in #1132.