### PR TITLE
fix: UnbinnedNLL.scaled_pdf scale for multivariate data

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -1041,7 +1041,9 @@ class UnbinnedNLL(UnbinnedCost):
     @property
     def scaled_pdf(self):
         """Get number density model."""
-        scale = np.prod(self.data.shape)
+        # number of data points: for multivariate data of shape (D, N) this
+        # is N, the last axis; for 1D data of shape (N,) it is also N
+        scale = self.data.shape[-1]
         if self._log:
             return lambda *args: scale * np.exp(self._model(*args))
         return lambda *args: scale * self._model(*args)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -384,6 +384,21 @@ def test_UnbinnedNLL_properties(log):
     assert c.verbose == 1
 
 
+def test_UnbinnedNLL_scaled_pdf_2D():
+    # for multivariate data of shape (D, N) the scale must be the number of
+    # data points N, not D * N
+    def model(x_y, mux, muy, sx, sy):
+        return mvnorm(mux, muy, sx, sy).pdf(x_y.T)
+
+    truth = 0.1, 0.2, 0.3, 0.4
+    x, y = mvnorm(*truth).rvs(size=15, random_state=1).T
+    c = UnbinnedNLL((x, y), model)
+
+    assert c.data.shape == (2, 15)
+    expected = 15 * model(c.data, *truth)
+    assert_allclose(c.scaled_pdf(c.data, *truth), expected)
+
+
 @pytest.mark.parametrize("log", (False, True))
 def test_UnbinnedNLL_visualize(log):
     pytest.importorskip("matplotlib")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Split out of #1137.

`scaled_pdf` must scale by the number of data points. For multivariate data of shape `(D, N)`, `np.prod(data.shape)` gives `D * N`, so the number density was too large by the factor `D`. `data.shape[-1]` is correct for 1D and multivariate data.

Reported in #1132.