### PR TITLE
fix: keep shape validation in _normalize_output for non-float output

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -2557,7 +2557,7 @@ def _normalize_output(x, kind, *shape, msg=None):
         warnings.warn(msg, PerformanceWarning, stacklevel=2)
         x = np.array(x)
         if x.dtype.kind != "f":
-            return x.astype(float)
+            x = x.astype(float)
     if x.ndim < len(shape):
         return x.reshape(*shape)
     elif x.shape != shape:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1791,6 +1791,21 @@ def test_NormalConstraint_pickle():
     assert_equal(c.covariance, c2.covariance)
 
 
+def test_model_wrong_shape_int_output():
+    # a model that returns an integer sequence with the wrong shape must still
+    # raise the shape error instead of slipping through the float early-return
+    def model(x, a):
+        return [1, 2]
+
+    c = LeastSquares([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], 1.0, model)
+    with pytest.warns(PerformanceWarning):
+        with pytest.raises(
+            ValueError,
+            match=r"output of model has shape \(2,\), but \(3,\) is required",
+        ):
+            c(1)
+
+
 def test_NormalConstraint_bad_input_1():
     with pytest.raises(ValueError, match="scalar or one-dimensional"):
         NormalConstraint("par", [[[1, 2]]], np.eye(2))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Split out of #1137.

A model that returned a non-float sequence took an early return before the shape check, so a wrong shape passed silently. The value is now converted to float and falls through to the shape check.