### PR TITLE
perf: cache total counts and avoid temporaries in Template._pred

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -906,12 +906,14 @@ class UnbinnedCost(MaskedCost):
         self._model_grad = grad
         super().__init__(_model_parameters(model, name), _norm(data), verbose)
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def pdf(self):
         """Get probability density model."""
         ...  # pragma: no cover
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def scaled_pdf(self):
         """Get number density model."""
         ...  # pragma: no cover
@@ -1304,12 +1306,13 @@ class BinnedCost(MaskedCostWithPulls):
     :meta private:
     """
 
-    __slots__ = "_xe", "_ndim", "_bohm_zech_n", "_bohm_zech_s"
+    __slots__ = "_xe", "_ndim", "_bohm_zech_n", "_bohm_zech_s", "_counts_total"
 
     _xe: Union[NDArray, Tuple[NDArray, ...]]
     _ndim: int
     _bohm_zech_n: NDArray
     _bohm_zech_s: Optional[NDArray]
+    _counts_total: float
 
     n = MaskedCost.data
 
@@ -1459,6 +1462,8 @@ class BinnedCost(MaskedCostWithPulls):
             self._bohm_zech_n = val * s
         else:
             self._bohm_zech_n = n
+        # cache the total number of entries in the unmasked bins
+        self._counts_total = np.sum(self._counts())
 
     def _transformed(self, val: NDArray) -> Tuple[NDArray, NDArray]:
         s = self._bohm_zech_s
@@ -1792,8 +1797,8 @@ class Template(BinnedCost):
         self._model_len = np.prod(self._xe_shape)
 
     def _pred(self, args: Sequence[float]) -> Tuple[NDArray, NDArray]:
-        mu: NDArray = 0  # type:ignore
-        mu_var: NDArray = 0  # type:ignore
+        mu = np.zeros(self._data.shape[: self._ndim])
+        mu_var = np.zeros_like(mu)
         i = 0
         for t1, t2 in self._model_data:
             if isinstance(t1, np.ndarray) and isinstance(t2, np.ndarray):
@@ -1812,7 +1817,9 @@ class Template(BinnedCost):
                 # subtraction, we set negative values to zero
                 d[d < 0] = 0
                 mu += d
-                mu_var += np.ones_like(mu) * 1e-300
+                # add a tiny floor to the variance to avoid exactly zero values;
+                # a scalar add avoids allocating full temporaries
+                mu_var += 1e-300
                 i += t2
             else:  # never arrive here
                 raise AssertionError  # pragma: no cover
@@ -1985,7 +1992,7 @@ class BinnedNLL(BinnedCostWithModel):
         if ma is not None:
             p /= np.sum(p[ma])
         # scale probabilities with total number of entries of unmasked bins in histogram
-        return p * np.sum(self._counts())
+        return p * self._counts_total
 
     def _value(self, args: Sequence[float]) -> float:
         mu = self._pred(args)
@@ -2004,7 +2011,7 @@ class BinnedNLL(BinnedCostWithModel):
             p /= psum
         # scale probabilities with total number of entries of unmasked bins in histogram
         n = self._counts()
-        ntot = np.sum(n)
+        ntot = self._counts_total
         mu = p * ntot
         gmu = pg * ntot
         ma = self.mask


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Split out of #1137. No behavior change.

- `BinnedCost` caches the total number of entries of the unmasked bins in `_update_cache`. `BinnedNLL._pred` and `_grad` summed the counts on every call.
- `Template._pred` added a full array of `1e-300` per component. A scalar add gives the same variance floor without the temporaries.
- Replaces `abc.abstractproperty`, deprecated since Python 3.3, with `property` over `abstractmethod`.

Touches the same region of `BinnedNLL._grad` as #1137, so a trivial conflict is possible depending on merge order.

Reported in #1132.