### PR TITLE
fix: make hide_modules restore state and qtwidget report missing Qt

### DIFF
--- a/src/iminuit/_hide_modules.py
+++ b/src/iminuit/_hide_modules.py
@@ -15,20 +15,36 @@ class HiddenModules(MetaPathFinder):
             )
 
 
+def _forget(names):
+    # A package caches its submodules as attributes, and `from pkg import mod`
+    # reads that attribute instead of importing. Drop both, or the next import
+    # returns the module that was loaded while the dependency was hidden.
+    for name in names:
+        sys.modules.pop(name, None)
+        parent, _, child = name.rpartition(".")
+        if parent in sys.modules:
+            with contextlib.suppress(AttributeError):
+                delattr(sys.modules[parent], child)
+
+
 @contextlib.contextmanager
 def hide_modules(*modules, reload=None):
+    """Hide modules and optionally force a reload of one or more other modules."""
+    if reload is None:
+        reload = ()
+    elif isinstance(reload, str):
+        reload = (reload,)
     saved = {}
     for m in tuple(sys.modules):
         for to_hide in modules:
             if m.startswith(to_hide):
-                saved[m] = sys.modules[m]
-                del sys.modules[m]
-    sys.meta_path.insert(0, HiddenModules(modules))
-    if reload and reload in sys.modules:
-        del sys.modules[reload]
-    yield
-    if reload and reload in sys.modules:
-        del sys.modules[reload]
-    sys.meta_path = sys.meta_path[1:]
-    for name, mod in saved.items():
-        sys.modules[name] = mod
+                saved[m] = sys.modules.pop(m)
+    finder = HiddenModules(modules)
+    sys.meta_path.insert(0, finder)
+    try:
+        _forget(reload)
+        yield
+    finally:
+        _forget(reload)
+        sys.meta_path.remove(finder)
+        sys.modules.update(saved)

--- a/src/iminuit/qtwidget.py
+++ b/src/iminuit/qtwidget.py
@@ -7,10 +7,12 @@ from typing import Dict, Any, Callable
 from contextlib import contextmanager
 
 try:
-    from PySide6 import QtCore, QtGui, QtWidgets
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
     from matplotlib import pyplot as plt
-except ModuleNotFoundError as e:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+    from PySide6 import QtCore, QtGui, QtWidgets
+except ImportError as e:
+    # Not only ModuleNotFoundError: if no Qt binding at all is installed,
+    # matplotlib.backends.qt_compat raises a plain ImportError.
     e.msg += (
         "\n\nPlease install PySide6, and matplotlib to enable interactive "
         "outside of Jupyter notebooks."

--- a/tests/test_hide_modules.py
+++ b/tests/test_hide_modules.py
@@ -1,0 +1,51 @@
+import sys
+
+import pytest
+
+from iminuit._hide_modules import hide_modules
+
+
+def test_reload_is_undone_for_from_import():
+    # The parent package caches the submodule as an attribute. Unless that
+    # attribute is dropped too, `from iminuit import cost` keeps returning the
+    # module that was imported while numba was hidden.
+    import iminuit.cost
+
+    before = iminuit.cost
+
+    with hide_modules("numba", reload="iminuit.cost"):
+        from iminuit import cost
+
+        hidden = cost
+        assert hidden is not before
+
+    from iminuit import cost
+
+    assert cost is not hidden
+
+
+def test_meta_path_restored_on_exception():
+    before = list(sys.meta_path)
+
+    with pytest.raises(ValueError), hide_modules("numba", reload="iminuit.cost"):
+        raise ValueError
+
+    assert sys.meta_path == before
+
+
+def test_meta_path_entry_removed_by_identity():
+    # Something inside the block may insert its own finder at the front.
+    class Finder:
+        def find_spec(self, fullname, path, target=None):
+            return None
+
+    extra = Finder()
+    before = list(sys.meta_path)
+
+    with hide_modules("numba"):
+        sys.meta_path.insert(0, extra)
+
+    try:
+        assert sys.meta_path == [extra, *before]
+    finally:
+        sys.meta_path.remove(extra)

--- a/tests/test_without_pyside6.py
+++ b/tests/test_without_pyside6.py
@@ -4,6 +4,17 @@ import pytest
 
 pytest.importorskip("matplotlib")
 
+# matplotlib probes these in turn and only fails once none of them can be imported
+QT_BINDINGS = ("PySide6", "PySide2", "PyQt5", "PyQt6")
+
+# forget what matplotlib cached about the Qt binding it found earlier
+QT_MODULES = (
+    "iminuit.qtwidget",
+    "matplotlib.backends.backend_qt5agg",
+    "matplotlib.backends.backend_qtagg",
+    "matplotlib.backends.qt_compat",
+)
+
 
 def test_pyside6_interactive_with_ipython():
     pytest.importorskip("IPython")
@@ -12,7 +23,7 @@ def test_pyside6_interactive_with_ipython():
     cost = LeastSquares([1.1, 2.2], [3.3, 4.4], 1, lambda x, a: a * x)
 
     with hide_modules("PySide6", reload="iminuit.qtwidget"):
-        with pytest.raises(ModuleNotFoundError, match="Please install PySide6"):
+        with pytest.raises(ImportError, match="Please install PySide6"):
             iminuit.Minuit(cost, 1).interactive()
 
 
@@ -22,5 +33,17 @@ def test_pyside6_interactive_without_ipython():
     cost = LeastSquares([1.1, 2.2], [3.3, 4.4], 1, lambda x, a: a * x)
 
     with hide_modules("PySide6", "IPython", reload="iminuit.qtwidget"):
-        with pytest.raises(ModuleNotFoundError, match="Please install PySide6"):
+        with pytest.raises(ImportError, match="Please install PySide6"):
+            iminuit.Minuit(cost, 1).interactive()
+
+
+def test_interactive_without_any_qt_binding():
+    # matplotlib raises a plain ImportError here, not ModuleNotFoundError,
+    # so the hint must still be added.
+    import iminuit
+
+    cost = LeastSquares([1.1, 2.2], [3.3, 4.4], 1, lambda x, a: a * x)
+
+    with hide_modules(*QT_BINDINGS, "IPython", reload=QT_MODULES):
+        with pytest.raises(ImportError, match="Please install PySide6"):
             iminuit.Minuit(cost, 1).interactive()


### PR DESCRIPTION
I'm not sure why we are hiding and reloading modules, this is generally frowned on in Python, but it was also buggy, so here's a fix.

:robot: _AI text below_ :robot:

Fixes two test failures that appear once ruff sorts imports (PR #1150), and one latent state leak.

**`_hide_modules.hide_modules`**

- On exit it deleted the reloaded module from `sys.modules`, but a package caches its submodules as attributes, so `from iminuit import cost` kept returning the module that was imported while numba was hidden. The attribute is now dropped too. This is why `import iminuit.cost as cost` worked but the equivalent-looking `from iminuit import cost` did not.
- `sys.meta_path` is now restored in a `finally` block, so a failed test no longer leaves every module hidden for the rest of the session.
- The finder is removed by identity instead of by position, so it survives another finder being inserted inside the block.
- `reload` now also accepts several module names.

**`qtwidget`**

It only caught `ModuleNotFoundError`. When no Qt binding at all is installed, `matplotlib.backends.qt_compat` raises a plain `ImportError`, so the hint to install PySide6 was lost and the user got "Failed to import any of the following Qt binding modules". It now catches `ImportError`.

New tests cover all of it. `tests/test_hide_modules.py` is new; `test_interactive_without_any_qt_binding` hides every Qt binding, which is the case CI hits.