### PR TITLE
fix: Minuit.scipy no longer mutates user NonlinearConstraint

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import operator
 import warnings
 from iminuit import util as mutil
@@ -1252,18 +1253,11 @@ class Minuit:
 
             for i, c in enumerate(constraints):
                 if isinstance(c, NonlinearConstraint):
-                    # build a new constraint instead of mutating the user's
-                    # object, which would double-wrap fun on a second call
-                    constraints[i] = NonlinearConstraint(
-                        Wrapped(c.fun),
-                        c.lb,
-                        c.ub,
-                        jac=c.jac,
-                        hess=c.hess,
-                        keep_feasible=c.keep_feasible,
-                        finite_diff_rel_step=c.finite_diff_rel_step,
-                        finite_diff_jac_sparsity=c.finite_diff_jac_sparsity,
-                    )
+                    # copy instead of mutating the user's object, which would
+                    # double-wrap fun on a second call
+                    c = copy.copy(c)
+                    c.fun = Wrapped(c.fun)
+                    constraints[i] = c
                 elif isinstance(c, LinearConstraint):
                     if not no_fixed_parameters:
                         x = cpar.copy()

--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1252,7 +1252,18 @@ class Minuit:
 
             for i, c in enumerate(constraints):
                 if isinstance(c, NonlinearConstraint):
-                    c.fun = Wrapped(c.fun)
+                    # build a new constraint instead of mutating the user's
+                    # object, which would double-wrap fun on a second call
+                    constraints[i] = NonlinearConstraint(
+                        Wrapped(c.fun),
+                        c.lb,
+                        c.ub,
+                        jac=c.jac,
+                        hess=c.hess,
+                        keep_feasible=c.keep_feasible,
+                        finite_diff_rel_step=c.finite_diff_rel_step,
+                        finite_diff_jac_sparsity=c.finite_diff_jac_sparsity,
+                    )
                 elif isinstance(c, LinearConstraint):
                     if not no_fixed_parameters:
                         x = cpar.copy()

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -205,6 +205,29 @@ def test_scipy_constraints_1(lb, fixed):
     assert m.accurate
 
 
+def test_scipy_nonlinear_constraint_not_mutated():
+    def fcn(a, x, y):
+        return a + x**2 + y**2
+
+    def confun(a, x, y):
+        return a
+
+    nc = scopt.NonlinearConstraint(confun, 0, np.inf)
+    fun_before = nc.fun
+
+    m = Minuit(fcn, a=3, x=1, y=2)
+    m.scipy(constraints=[nc])
+    assert_allclose(m.values, [0, 0, 0], atol=1e-3)
+    assert nc.fun is fun_before
+
+    # a second call fails if fun is double-wrapped, because the wrapper expects
+    # the original positional signature
+    m2 = Minuit(fcn, a=3, x=1, y=2)
+    m2.scipy(constraints=[nc])
+    assert_allclose(m2.values, [0, 0, 0], atol=1e-3)
+    assert nc.fun is fun_before
+
+
 @pytest.mark.parametrize("fixed", (False, True))
 def test_scipy_constraints_2(fixed):
     def fcn(x, y):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit.scipy` replaced the `fun` attribute of each `NonlinearConstraint` given by the user with a wrapper. This changed the object of the user. A second call wrapped the already wrapped function again, and the fit then failed. The fix builds a new `NonlinearConstraint` from the wrapped function and the other attributes, and leaves the object of the user unchanged.

Split from #1138, part of #1132.