### PR TITLE
fix: minimize accepts scalar Bounds and documents callback behaviour

### DIFF
--- a/src/iminuit/minimize.py
+++ b/src/iminuit/minimize.py
@@ -30,6 +30,12 @@ def minimize(
     For a general description of the arguments of this function, see
     ``scipy.optimize.minimize``. We list only a few in the following.
 
+    .. note::
+
+        Unlike ``scipy.optimize.minimize``, where ``callback`` is invoked once per
+        iteration, here ``callback`` is invoked on *every* function evaluation. This
+        is a deviation from the scipy API.
+
     Parameters
     ----------
     method: str
@@ -95,7 +101,11 @@ def minimize(
     m = Minuit(wrapped_fun, x0, grad=wrapped_grad)
     if bounds is not None:
         if isinstance(bounds, Bounds):
-            m.limits = [(a, b) for a, b in zip(bounds.lb, bounds.ub)]
+            # scipy.optimize.Bounds allows scalar lb/ub, which broadcast over all
+            # parameters; mirror that here so e.g. Bounds(0, 1) works.
+            lb = np.broadcast_to(bounds.lb, len(x0))
+            ub = np.broadcast_to(bounds.ub, len(x0))
+            m.limits = [(a, b) for a, b in zip(lb, ub)]
         else:
             m.limits = bounds
     if tol:
@@ -132,7 +142,7 @@ def minimize(
         if m.accurate:
             message += "."
         else:
-            message += ", but uncertainties are unrealiable."
+            message += ", but uncertainties are unreliable."
     else:
         message = "Optimization failed."
         fmin = m.fmin

--- a/tests/test_minimize.py
+++ b/tests/test_minimize.py
@@ -131,6 +131,13 @@ def test_bounds():
     assert_equal(r1.x, r2.x)
 
 
+def test_bounds_scalar():
+    # scipy.optimize.Bounds allows scalar lb/ub that broadcast over all parameters
+    r = minimize(func, (1.5, 1.7, 1.5), bounds=opt.Bounds(0.5, 1.5))
+    assert r.success
+    assert_allclose(r.x, (0.5, 1, 1.5), atol=1e-2)
+
+
 def test_method_warn():
     with pytest.raises(ValueError):
         minimize(func, (1.5, 1.7, 1.5), method="foo")
@@ -145,7 +152,7 @@ def test_unreliable_uncertainties():
     r = minimize(func, (1.5, 1.7, 1.5), options={"stra": 0})
     assert (
         r.message
-        == "Optimization terminated successfully, but uncertainties are unrealiable."
+        == "Optimization terminated successfully, but uncertainties are unreliable."
     )
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`minimize()` raised a `ValueError` when given a `scipy.optimize.Bounds`
with scalar `lb`/`ub`, such as `Bounds(0, 1)`. scipy allows scalar
bounds to broadcast over all parameters, but `minimize()` did not
support this. The fix broadcasts `lb`/`ub` to the number of
parameters with `np.broadcast_to` before building the limits list.

This also fixes a typo ("unrealiable" -> "unreliable") in the
optimization result message, and documents that `callback` is
invoked on every function evaluation, unlike scipy where it is
invoked once per iteration.

Split from #1138, part of #1132.