### PR TITLE
fix: scan with all parameters fixed or many free parameters

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -963,6 +963,11 @@ class Minuit:
             actual number will be close to this, the scan uses ncall^(1/npar) steps per
             cube dimension. If no value is given, a heuristic is used to set ncall.
 
+        Raises
+        ------
+        RuntimeError
+            If all parameters are fixed, there is nothing to scan.
+
         Notes
         -----
         The scan can return an invalid minimum, this is not a cause for alarm. It just
@@ -996,9 +1001,11 @@ class Minuit:
         #  self._fmin = mutil.FMin(fm, self._fcn.nfcn, self._fcn.ngrad, self._tolerance)
 
         n = self.nfit
+        if n == 0:
+            raise RuntimeError("all parameters are fixed")
         if ncall is None:
             ncall = self._migrad_maxcall()
-        nstep = int(ncall ** (1 / n))
+        nstep = max(2, int(ncall ** (1 / n)))
 
         if self._last_state == self._init_state:
             # avoid overriding initial state

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1912,3 +1912,23 @@ def test_reset_resets_all_counters():
     assert m._fcn._ngrad == 0
     assert m._fcn._ng2 == 0
     assert m._fcn._nhessian == 0
+
+
+def test_scan_all_fixed():
+    m = Minuit(func0, x=1, y=2)
+    m.fixed = True
+    with pytest.raises(RuntimeError, match="all parameters are fixed"):
+        m.scan()
+
+
+def test_scan_many_free_params():
+    # with many free parameters, the old code computed nstep == 1 (degenerate);
+    # the scan should still vary every parameter and find the minimum
+    def cost(*par):
+        return sum((p - i) ** 2 for i, p in enumerate(par))
+
+    n = 5
+    m = Minuit(cost, *([0.0] * n), name=[f"p{i}" for i in range(n)])
+    m.limits = (-5, 5)
+    m.scan(ncall=20)
+    assert_allclose(m.values, range(n), atol=1.0)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit.scan()` divided by zero when all parameters were fixed. It now raises `RuntimeError`, the same as `draw_mncontour` does in this case. `scan()` also computed the number of steps per dimension as low as 1 when many parameters were free, which made the scan degenerate to a single point. The step count is now clamped to at least 2. Split from #1138, part of #1132.