### PR TITLE
fix: accept negative and numpy integer parameter indices

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import operator
 import warnings
 from iminuit import util as mutil
 from iminuit.util import _replace_none as replace_none
@@ -32,6 +33,7 @@ from typing import (
     Collection,
     Set,
     Sized,
+    SupportsIndex,
 )
 from iminuit.typing import UserBound, Cost, CostVector
 from iminuit._optional_dependencies import optional_module_for
@@ -2484,11 +2486,20 @@ class Minuit:
             pr.eps = self._precision
         return pr
 
-    def _normalize_key(self, key: Union[int, str]) -> Tuple[int, str]:
-        if isinstance(key, int):
-            if key >= self.npar:
-                raise ValueError(f"parameter {key} is out of range (max: {self.npar})")
-            return key, self._pos2var[key]
+    def _normalize_key(self, key: Union[SupportsIndex, str]) -> Tuple[int, str]:
+        if not isinstance(key, str):
+            # accept Python int, numpy integers, and other SupportsIndex types
+            try:
+                i = operator.index(key)
+            except TypeError:
+                raise ValueError(f"unknown parameter {key!r}") from None
+            if i < 0:
+                i += self.npar
+            if i < 0 or i >= self.npar:
+                raise ValueError(
+                    f"parameter {key} is out of range (max: {self.npar - 1})"
+                )
+            return i, self._pos2var[i]
         if key not in self._var2pos:
             raise ValueError(f"unknown parameter {key!r}")
         return self._var2pos[key], key

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -913,6 +913,31 @@ def test_mnprofile_bad_grid():
         m.mnprofile("y", grid=[[10, 20]])
 
 
+def test_normalize_key_negative_and_numpy_int():
+    m = Minuit(func0, x=0, y=0)
+    m.migrad()
+
+    # negative index
+    x, y, _ = m.mnprofile(-1, size=3)
+    x2, y2, _ = m.mnprofile(1, size=3)
+    assert_allclose(x, x2)
+
+    # numpy integer index
+    x3, y3, _ = m.mnprofile(np.int64(0), size=3)
+    x4, y4, _ = m.mnprofile(0, size=3)
+    assert_allclose(x3, x4)
+
+    # out-of-range index gives a clear error mentioning the correct max
+    with pytest.raises(ValueError, match="out of range"):
+        m.mnprofile(2)
+    with pytest.raises(ValueError, match="out of range"):
+        m.mnprofile(-3)
+
+    # a key that is neither a string nor index-able is reported as unknown
+    with pytest.raises(ValueError, match="unknown parameter 1.5"):
+        m.mnprofile(1.5)
+
+
 def test_contour_subtract():
     m = Minuit(func0, x=1.0, y=2.0)
     m.migrad()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit._normalize_key` only accepted a Python `int` as a positional key. A numpy integer fell through to the string branch and gave a confusing "unknown parameter" error. A negative index passed straight into the C++ layer and raised a `TypeError`. The out-of-range message also reported `npar` as the maximum, but the largest valid index is `npar - 1`.

The method now uses `operator.index`, so numpy integers and other `SupportsIndex` types work. Negative indices count from the end. The error message reports the correct maximum.

Split from #1138, part of #1132.