### PR TITLE
fix: per-parameter limits in experimental mncontour and draw_mnmatrix off-by-one

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1698,7 +1698,7 @@ class Minuit:
         vname : int or str
             Parameter to scan over.
         size : int, optional
-            Number of scanning points (Default: 100). Ignored if grid is set.
+            Number of scanning points (Default: 30). Ignored if grid is set.
         bound : tuple of float or float, optional
             If bound is tuple, (left, right) scanning bound.
             If bound is a number, it specifies an interval of N :math:`\sigma`
@@ -2384,6 +2384,9 @@ class Minuit:
                 a, b = prange[par1]
                 extremes = []
                 for k, (xk, yk) in enumerate(zip(x, y)):
+                    if k == 0:
+                        # y[k - 1] would wrap around to the last point
+                        continue
                     if yk < fmax and y[k - 1] > fmax:
                         extremes.append(x[k - 1])
                     if yk > fmax and y[k - 1] < fmax:
@@ -2668,12 +2671,11 @@ class Minuit:
                     z * s[1] * np.sin(phi),  # noqa: B023
                 )
                 x = r[0] + center[0]
-                lim = self.limits[ix]
-                if lim is not None:
-                    x = max(lim[0], min(x, lim[1]))
+                xlim = self.limits[ix]
+                x = max(xlim[0], min(x, xlim[1]))
                 y = r[1] + center[1]
-                if lim is not None:
-                    y = max(lim[0], min(y, lim[1]))
+                ylim = self.limits[iy]
+                y = max(ylim[0], min(y, ylim[1]))
                 return x, y
 
             def scan(z):

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1830,3 +1830,24 @@ def test_migrad_iterative_with_precision():
     m2.migrad(iterate=1)
 
     assert m2.fmin.nfcn < m1.fmin.nfcn
+
+
+def test_mncontour_experimental_per_param_limits():
+    pytest.importorskip("scipy.optimize")
+
+    def cost(x, y):
+        return x**2 + y**2
+
+    m = Minuit(cost, x=0.5, y=0.5)
+    m.limits["x"] = (-0.3, 5)
+    m.limits["y"] = (-5, 0.3)
+    m.migrad()
+
+    cont = m.mncontour(0, 1, size=30, experimental=True)
+    # regression: y was clamped with the limits of x
+    assert np.all(cont[:, 0] >= -0.3 - 1e-9)
+    assert np.all(cont[:, 1] <= 0.3 + 1e-9)
+
+    cont0 = m.mncontour(0, 1, size=30, experimental=False)
+    assert np.all(cont0[:, 0] >= -0.3 - 1e-9)
+    assert np.all(cont0[:, 1] <= 0.3 + 1e-9)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit._experimental_mncontour` clamped both contour coordinates with the limits of the x parameter. If the two parameters had different limits, the y values could leave their allowed range. The fix clamps each coordinate with the limits of its own parameter. A new test checks that each parameter stays in its own range.

`Minuit.draw_mnmatrix` compared `y[k]` with `y[k - 1]` for `k = 0`, which wraps around to the last point and can add a wrong extreme. The loop now skips the first point.

The `mnprofile` docstring said the default of `size` is 100. The signature uses 30.

Split from #1138, part of #1132.