### PR TITLE
chore: use dependency groups instead of extras

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      # pip install .[test] is not used here to test minimum (faster)
+      # the test dependency group is not used here to test minimum (faster)
       # cov workflow runs all tests
       - run: uv pip install --system . pytest pytest-xdist ${{ matrix.installs }}
       - run: pytest -n 3

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -49,8 +49,7 @@ If you prefer to manage the virtual environment yourself, the dependency groups 
 
 .. code-block:: bash
 
-    uv pip install -e. --group test
-    python -m pytest -n auto
+    uv run pytest -n auto
 
 Generate a coverage report:
 

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -45,6 +45,13 @@ You have the source code now, next you want to build and test. We recommend to u
 
 This installs your version of ``iminuit`` locally and all the dependencies needed to run the tests, and then runs the tests.
 
+If you prefer to manage the virtual environment yourself, the dependency groups ``test``, ``doc``, and ``dev`` (both) in ``pyproject.toml`` list what you need. For example, with ``uv``:
+
+.. code-block:: bash
+
+    uv pip install -e. --group test
+    python -m pytest -n auto
+
 Generate a coverage report:
 
 .. code-block:: bash

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(".")
 import python_releases
 
-nox.needs_version = ">=2024.3.2"
+nox.needs_version = ">=2025.2.9"
 nox.options.default_venv_backend = "uv|virtualenv"
 
 ENV = {
@@ -21,6 +21,7 @@ ENV = {
 PYPROJECT = nox.project.load_toml("pyproject.toml")
 MINIMUM_PYTHON = PYPROJECT["project"]["requires-python"].strip(">=")
 LATEST_PYTHON = str(python_releases.latest())
+DEPS = {g: nox.project.dependency_groups(PYPROJECT, g) for g in ("test", "dev")}
 
 nox.options.sessions = ["test", "mintest", "maxtest"]
 
@@ -28,7 +29,7 @@ nox.options.sessions = ["test", "mintest", "maxtest"]
 @nox.session(reuse_venv=True)
 def test(session: nox.Session) -> None:
     """Run all tests."""
-    session.install("--only-binary=:all:", "-e.[test]")
+    session.install("--only-binary=:all:", "-e.", *DEPS["test"])
     extra_args = session.posargs if session.posargs else ("-n=auto",)
     session.run("pytest", *extra_args, env=ENV)
 
@@ -70,7 +71,7 @@ def pypy(session: nox.Session) -> None:
 @nox.session(venv_backend="uv", reuse_venv=True)
 def cov(session: nox.Session) -> None:
     """Run covage and place in 'htmlcov' directory."""
-    session.install("--only-binary=:all:", "-e.[test,doc]")
+    session.install("--only-binary=:all:", "-e.", *DEPS["dev"])
     session.run("coverage", "run", "-m", "pytest", env=ENV)
     session.run("coverage", "html", "-d", "build/htmlcov")
     session.run("coverage", "report", "-m")
@@ -80,7 +81,7 @@ def cov(session: nox.Session) -> None:
 @nox.session(python="3.11", reuse_venv=True)
 def doc(session: nox.Session) -> None:
     """Build html documentation."""
-    session.install("--only-binary=:all:", "-e.[test,doc]")
+    session.install("--only-binary=:all:", "-e.", *DEPS["dev"])
 
     # link check
     session.run(
@@ -96,7 +97,7 @@ def doc(session: nox.Session) -> None:
 @nox.session(python="3.11", reuse_venv=True)
 def links(session: nox.Session) -> None:
     """Check all links in the documentation."""
-    session.install("--only-binary=:all:", "-e.[test,doc]")
+    session.install("--only-binary=:all:", "-e.", *DEPS["dev"])
 
     # link check
     session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = ["numpy >=1.21"]
 repository = "https://github.com/scikit-hep/iminuit"
 documentation = "https://scikit-hep.org/iminuit"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     "coverage",
     "ipywidgets",
@@ -70,6 +70,7 @@ doc = [
     "jaxlib",
     "pytest-xdist",
 ]
+dev = [{ include-group = "test" }, { include-group = "doc" }]
 
 [tool.scikit-build]
 minimum-version = "build-system.requires"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Move the `test` and `doc` extras to PEP 735 `[dependency-groups]` and add a `dev` group that includes both. The extras were only used by `noxfile.py`, which now resolves the groups with `nox.project.dependency_groups` (requires nox>=2025.2.9). The contribute guide gets a short note on how to install a group without nox.

CI is unchanged: the docs and coverage workflows go through nox, and the test workflow installs packages explicitly.