### PR TITLE
fix: raise proper exceptions from Params/MErrors indexing and FMin equality

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -6,6 +6,7 @@ You can look up the interface of data classes that iminuit uses here.
 
 from __future__ import annotations
 import inspect
+import operator
 from collections import OrderedDict
 from argparse import Namespace
 from iminuit import _repr_html, _repr_text, _deprecated
@@ -675,6 +676,8 @@ class FMin:
 
     def __eq__(self, other: object) -> bool:
         """Return True if all attributes are equal."""
+        if not isinstance(other, FMin):
+            return NotImplemented
 
         def relaxed_equal(k: str, a: object, b: object) -> bool:
             a = getattr(a, k)
@@ -837,7 +840,8 @@ class Params(tuple):
                 if p.name == key:
                     key = i
                     break
-        assert isinstance(key, (int, slice))
+            else:
+                raise KeyError(key)
         return super(Params, self).__getitem__(key)
 
     def __str__(self) -> str:
@@ -950,18 +954,26 @@ class MErrors(OrderedDict):
         else:
             p.text(str(self))
 
-    def __getitem__(self, key: Union[int, str]) -> MError:
+    def __getitem__(self, key: Union[SupportsIndex, str]) -> MError:
         """Get item at key, which can be an index or a parameter name."""
-        if isinstance(key, int):
-            if key < 0:
-                key += len(self)
-            if key < 0 or key >= len(self):
+        if not isinstance(key, str):
+            # Accept any integer-like key (including numpy integers) by
+            # converting it with operator.index, which raises TypeError for
+            # non-integer, non-str keys.
+            try:
+                index = operator.index(key)
+            except TypeError:
+                raise TypeError(
+                    f"key must be an integer or parameter name, not {key!r}"
+                ) from None
+            if index < 0:
+                index += len(self)
+            if index < 0 or index >= len(self):
                 raise IndexError("index out of range")
             for i, k in enumerate(self):
-                if i == key:
+                if i == index:
                     key = k
                     break
-        assert isinstance(key, str)
         return OrderedDict.__getitem__(self, key)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -237,6 +237,10 @@ def test_Params():
     assert p["foo"].number == 0
     assert p["bar"].number == 1
 
+    # an unknown name raises KeyError, not a bare AssertionError
+    with pytest.raises(KeyError):
+        p["baz"]
+
 
 def test_MError():
     me = util.MError(
@@ -324,6 +328,24 @@ def test_MErrors():
 
     assert repr(mes) == f"<MErrors\n  {mes['x']!r}\n>"
 
+    # indexing works with str and integer keys, including numpy integers
+    assert mes["x"].name == "x"
+    assert mes[0].name == "x"
+    assert mes[np.int64(0)].name == "x"
+    assert mes[-1].name == "x"
+
+    # out-of-range integer raises IndexError
+    with pytest.raises(IndexError):
+        mes[1]
+
+    # unknown name raises KeyError
+    with pytest.raises(KeyError):
+        mes["y"]
+
+    # a non-integer, non-str key raises TypeError, not a bare AssertionError
+    with pytest.raises(TypeError):
+        mes[1.5]
+
 
 @pytest.mark.parametrize("errordef", (0.5, 1.0))
 def test_FMin(errordef):
@@ -377,6 +399,12 @@ def test_FMin(errordef):
     assert fmin != util.FMin(fm, "foo", 1, 2, 0, 0, 1, 0.3, 1.2)
     assert fmin != util.FMin(fm, "bar", 1, 2, 0, 0, 1, 0.1, 1.2)
     assert fmin != util.FMin(fm, "foo", 1, 2, 0, 0, 1, 0.1, 1.5)
+
+    # comparison with non-FMin objects returns False instead of raising
+    assert fmin != 5
+    assert fmin != None
+    assert not (fmin == None)
+    assert (fmin == 5) is False
 
     if errordef == 1:
         reduced_chi2 = fmin.fval


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Params.__getitem__` and `MErrors.__getitem__` raised a bare `AssertionError` for an unknown parameter name or a non-integer key, and `MErrors` rejected numpy integer keys. `FMin.__eq__` raised `AttributeError` when compared to a non-`FMin` object instead of returning `NotImplemented`. This PR fixes all three: unknown names now raise `KeyError`, non-integer/non-str keys raise `TypeError`, numpy integers are accepted, and `fmin == 5` / `fmin == None` now work as expected.

Split out of #1139. Addresses part of #1132.
