### PR TITLE
fix: describe() accepts Annotated with non-float base type

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1377,8 +1377,7 @@ def _get_limit(
     if get_origin(annotation) is not Annotated:
         return None
 
-    # The base type (first argument) is irrelevant for limit extraction;
-    # accept any base type, not just float.
+    # The base type (first argument) is irrelevant for limit extraction.
     _, *constraints = get_args(annotation)
     lower = -np.inf
     upper = np.inf

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1377,8 +1377,9 @@ def _get_limit(
     if get_origin(annotation) is not Annotated:
         return None
 
-    tp, *constraints = get_args(annotation)
-    assert tp is float
+    # The base type (first argument) is irrelevant for limit extraction;
+    # accept any base type, not just float.
+    _, *constraints = get_args(annotation)
     lower = -np.inf
     upper = np.inf
     for c in constraints:

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -225,6 +225,24 @@ def test_with_type_hints():
     assert r == {"x": None, "a": (0, 1), "b": None}
 
 
+def test_with_type_hints_non_float_base():
+    # The base type of an Annotated hint is irrelevant for limit extraction.
+    # Bases other than float (e.g. int or np.float64) must not crash describe()
+    # (regression test for an AssertionError that broke Minuit construction).
+    def foo(
+        x: NDArray,
+        a: Annotated[int, Gt(0), Lt(1)],
+        b: Annotated[np.float64, Ge(1)],
+    ): ...
+
+    r = describe(foo, annotations=True)
+    assert r == {
+        "x": None,
+        "a": (0, 1),
+        "b": (1, np.inf),
+    }
+
+
 def test_with_pydantic_types():
     tp = pytest.importorskip("pydantic.types")
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Annotated[int, Gt(0)]` or `Annotated[np.float64, Gt(0)]` crashed `describe()` and `Minuit` construction with `AssertionError`; the base type does not matter for limit extraction.

Split out of #1139. Addresses part of #1132.
