### PR TITLE
fix: do not assert in FMin text repr when Hesse failed

### DIFF
--- a/src/iminuit/_repr_text.py
+++ b/src/iminuit/_repr_text.py
@@ -60,8 +60,10 @@ def fmin_fields(fm):
         covariance_msg1 = "Hesse FAILED"
         if fm.has_reached_call_limit:
             covariance_msg2 = "ABOVE call limit"
+        elif fm.has_posdef_covar:
+            # unexpected combination, but degrade gracefully instead of raising
+            covariance_msg2 = "Covariance pos. def."
         else:
-            assert not fm.has_posdef_covar
             covariance_msg2 = "Covariance NOT pos. def."
     else:
         if fm.has_covariance:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -294,6 +294,31 @@ def test_text_fmin_not_posdef():
     assert _repr_text.fmin(fmin) == ref("fmin_not_posdef.txt")
 
 
+def test_text_fmin_hesse_failed_but_posdef():
+    # An unexpected state combination from Minuit2 (Hesse failed while still
+    # reporting a positive definite covariance) must not make str(fmin) raise.
+    fm = Namespace(
+        fval=11.456,
+        edm=1.23456e-10,
+        up=0.5,
+        is_valid=False,
+        has_valid_parameters=False,
+        has_accurate_covar=False,
+        has_posdef_covar=True,
+        has_made_posdef_covar=False,
+        hesse_failed=True,
+        has_covariance=False,
+        is_above_max_edm=False,
+        has_reached_call_limit=False,
+        has_parameters_at_limit=False,
+        errordef=1,
+        state=[],
+    )
+    fmin = FMin(fm, "Migrad", 10, 3, 0, 0, 10, 1e-4, 0.01)
+    text = _repr_text.fmin(fmin)
+    assert "Hesse FAILED" in text
+
+
 def test_text_fmin_made_posdef():
     fm = Namespace(
         fval=11.456,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Minuit2 can report `hesse_failed` together with `has_posdef_covar`, a combination the text repr did not expect. It asserted this could not happen, so `str(fmin)` raised `AssertionError` instead of printing a diagnostic message. Now this state degrades gracefully, showing "Covariance pos. def." alongside "Hesse FAILED".

Split out of #1139. Addresses part of #1132.
