### PR TITLE
fix: honor numpy boolean masks in parameter views

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -150,7 +150,9 @@ class BasicView(abc.ABC):
 
 def _ndim(obj: Any) -> int:
     nd = 0
-    while isinstance(obj, Iterable):
+    # A str is Iterable, but indexing it yields another str, which would
+    # cause an infinite loop here; treat it (and other str-likes) as scalar.
+    while isinstance(obj, Iterable) and not isinstance(obj, str):
         nd += 1
         for x in obj:
             if x is not None:
@@ -1442,8 +1444,13 @@ def _key2index(
     if isinstance(key, slice):
         return _key2index_from_slice(var2pos, key)
     if not isinstance(key, str) and isinstance(key, Iterable):
-        # convert boolean masks into list of indices
-        if isinstance(key[0], bool):
+        # convert into a list so we can index it and check for emptiness;
+        # this also materializes generators and numpy arrays
+        key = list(key)
+        # convert boolean masks into list of indices; np.bool_ is not a
+        # subclass of bool, so we must check for it explicitly, otherwise
+        # numpy booleans would be silently interpreted as integer indices
+        if key and isinstance(key[0], (bool, np.bool_)):
             key = [k for k in range(len(var2pos)) if key[k]]
         return [_key2index_item(var2pos, k) for k in key]
     return _key2index_item(var2pos, key)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,6 +20,11 @@ def test_ndim():
     assert ndim((None, None)) == 1
     assert ndim(((1, 2), None)) == 2
     assert ndim((None, (1, 2))) == 2
+    # a str is treated as a scalar; otherwise this would loop forever, since
+    # indexing a 1-char str yields the str itself (reachable via e.g.
+    # m.limits[:] = "ab" typos)
+    assert ndim("ab") == 0
+    assert ndim("") == 0
 
 
 # def test_BasicView():
@@ -78,6 +83,21 @@ def test_ValueView():
     assert_equal(v[[2, 0]], (3, 1))
     v[["x", "z"]] = (3, 1)
     assert_equal(v, (3, 2, 1))
+
+    # boolean masks must be honored as masks, not silently read as integer
+    # indices. This must hold for both plain-bool lists and numpy bool arrays,
+    # since np.bool_ is not a subclass of the builtin bool.
+    v[:] = (1, 2, 3)
+    assert_equal(v[[True, False, True]], (1, 3))
+    assert_equal(v[np.array([True, False, True])], (1, 3))
+    v[np.array([True, False, True])] = (4, 5)
+    assert_equal(v, (4, 2, 5))
+    v[[True, False, True]] = (1, 3)
+    assert_equal(v, (1, 2, 3))
+
+    # an empty key selects nothing instead of raising IndexError
+    assert_equal(v[[]], [])
+    assert_equal(v[np.array([], dtype=bool)], [])
 
 
 def test_FixedView_as_mask_for_other_views():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`m.values[mask]` (and similar indexing on parameter views) read a numpy
boolean array as integer indices, since `np.bool_` is not a subclass of
`bool`. An empty key raised `IndexError` instead of selecting nothing, and
`_ndim("ab")` looped forever because indexing a string yields another
string.

Split out of #1139. Addresses part of #1132.
