### PR TITLE
fix: make hide_modules exception-safe and cheapen is_module_available

### DIFF
--- a/src/iminuit/_hide_modules.py
+++ b/src/iminuit/_hide_modules.py
@@ -46,5 +46,7 @@ def hide_modules(*modules, reload=None):
         yield
     finally:
         _forget(reload)
-        sys.meta_path.remove(finder)
+        # already gone if the block itself modified sys.meta_path
+        with contextlib.suppress(ValueError):
+            sys.meta_path.remove(finder)
         sys.modules.update(saved)

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -7,6 +7,7 @@ You can look up the interface of data classes that iminuit uses here.
 from __future__ import annotations
 import inspect
 import operator
+import importlib.util
 from collections import OrderedDict
 from argparse import Namespace
 from iminuit import _repr_html, _repr_text, _deprecated
@@ -1784,11 +1785,10 @@ def is_jupyter() -> bool:
 def is_module_available(module: str) -> bool:
     """Return True if a module is available."""
     try:
-        import importlib
-
-        importlib.import_module(module)
-        return True
+        # find_spec only inspects metadata; it is much cheaper than a full import.
+        return importlib.util.find_spec(module) is not None
     except ModuleNotFoundError:
+        # raised if a parent package of a dotted name is missing
         return False
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -668,6 +668,48 @@ def test_replace_none():
     assert util._replace_none(3, 2) == 3
 
 
+def test_is_module_available():
+    assert is_module_available("numpy") is True
+    assert is_module_available("a_module_that_does_not_exist_xyz") is False
+    # a missing parent package must not raise, just return False
+    assert is_module_available("a_module_that_does_not_exist_xyz.sub") is False
+
+
+def test_hide_modules_restores_on_exception():
+    import sys
+
+    import json  # noqa: F401  (imported so it can be hidden and restored)
+
+    meta_path_before = list(sys.meta_path)
+
+    with pytest.raises(RuntimeError):
+        with hide_modules("json"):
+            assert "json" not in sys.modules
+            raise RuntimeError("boom")
+
+    # both sys.meta_path and the hidden module are restored despite the error
+    assert list(sys.meta_path) == meta_path_before
+    assert "json" in sys.modules
+
+
+def test_hide_modules_finder_already_removed():
+    import sys
+
+    import json  # noqa: F401
+
+    meta_path_before = list(sys.meta_path)
+
+    with hide_modules("json"):
+        # code inside the block rebuilds sys.meta_path without our finder;
+        # exit must not raise even though there is nothing to remove
+        sys.meta_path = [
+            f for f in sys.meta_path if type(f).__name__ != "HiddenModules"
+        ]
+
+    assert list(sys.meta_path) == meta_path_before
+    assert "json" in sys.modules
+
+
 def test_progressbar(capsys):
     with util.ProgressBar(max_value=4) as bar:
         for i in range(4):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`hide_modules` removed its finder from `sys.meta_path` by identity, but did not guard against the finder already being gone, so an exception raised inside the `with` block (or code that rebuilt `sys.meta_path`) could raise `ValueError` on exit instead of restoring `sys.meta_path` and the hidden modules. `is_module_available` now checks for a module spec instead of fully importing the module, which is cheaper and avoids import side effects.

Split out of #1139. Addresses part of #1132.
