### PR TITLE
ci: add Python 3.15 to tests and wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-26-intel, macos-latest, ubuntu-24.04-arm, windows-11-arm]
-        py: [cp39, cp310, cp311, cp312, cp313, cp314, cp314t]
+        py: [cp39, cp310, cp311, cp312, cp313, cp314, cp314t, cp315, cp315t]
         exclude:
           - os: ubuntu-24.04-arm
             py: cp39

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,9 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.14"
             installs: "'numpy>=2' scipy matplotlib"
+          - os: ubuntu-latest
+            python-version: "3.15"
+            installs: "'numpy>=2' scipy"
       fail-fast: false
     steps:
       - uses: actions/checkout@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,10 @@ no_implicit_optional = false
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-skip = ["cp39-musllinux_i686"]                    # no numpy wheel
+skip = [
+    "cp39-musllinux_i686", # no numpy wheel
+    "*t-win32",            # no numpy wheel
+]
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a Python 3.15 test job on Ubuntu (numpy + scipy; matplotlib has no cp315 wheels yet) and `cp315`/`cp315t` to the wheel build matrix.