### PR TITLE
fix: fall back to ndarray repr for non-square Matrix

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -293,10 +293,13 @@ class Matrix(np.ndarray):
         else:
             self._var2pos = getattr(obj, "_var2pos", {})
 
+    def _is_square(self) -> bool:
+        return self.ndim == 2 and self.shape[0] == self.shape[1]
+
     def _names(self) -> Tuple[str, ...]:
         # Positional labels if names are unknown or stale, e.g. after numpy
         # fancy indexing produced a non-square matrix.
-        if self.ndim == 2 and self.shape[0] == self.shape[1] == len(self._var2pos):
+        if self._is_square() and self.shape[0] == len(self._var2pos):
             return tuple(self._var2pos)
         return tuple(str(i) for i in range(len(self)))
 
@@ -394,11 +397,13 @@ class Matrix(np.ndarray):
 
     def __str__(self):
         """Get user-friendly text representation."""
-        if self.ndim != 2:
+        if not self._is_square():
             return repr(self)
         return _repr_text.matrix(self)
 
     def _repr_html_(self):
+        if not self._is_square():
+            return f"<pre>{repr(self)}</pre>"
         return _repr_html.matrix(self)
 
     def _repr_pretty_(self, p, cycle):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -214,6 +214,11 @@ def test_Matrix():
     m4 = m[np.array([0, 2])]
     assert_equal(m4, [[0, 1, 2], [6, 7, 8]])  # 2x3, not square
     assert m4._names() == ("0", "1")
+    # non-square matrices fall back to the plain ndarray repr
+    assert str(m4) == repr(m4)
+    assert "<pre>" in m4._repr_html_()
+    assert str(m[0]) == repr(m[0])
+    assert "<pre>" in m[0]._repr_html_()
 
     # slicing an untracked matrix stays untracked instead of raising
     m5 = m4[:1]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #1139. `str()` and `_repr_html_()` on a `Matrix` assumed a square matrix and raised `IndexError` for 1D or non-square results of numpy indexing, such as `cov[np.array([0, 2])]` or `cov[0]`. They now fall back to the plain ndarray repr in that case.