### PR TITLE
ci: build pyodide wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,13 @@ jobs:
 
   pyodide:
     needs: release_check
-    name: pyodide
+    name: ${{ matrix.py }} pyodide
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py: [cp313, cp314, cp315]
+
     steps:
       - uses: actions/checkout@v7
         with:
@@ -85,10 +90,12 @@ jobs:
       - uses: pypa/cibuildwheel@v4.2
         env:
           CIBW_PLATFORM: pyodide
+          CIBW_BUILD: ${{ matrix.py }}-*
+          CIBW_ENABLE: pyodide-prerelease
 
       - uses: actions/upload-artifact@v7
         with:
-          name: pyodide-wheels
+          name: wheel-${{ matrix.py }}-pyodide
           path: ./wheelhouse/*.whl
 
   sdist:
@@ -129,10 +136,9 @@ jobs:
       attestations: write
 
     steps:
-      # pyodide wheels are not accepted by PyPI; they go on the GitHub release
       - uses: actions/download-artifact@v8
         with:
-          pattern: "{sdist,wheel-*}"
+          pattern: "*"
           merge-multiple: true
           path: dist
 
@@ -149,14 +155,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          name: pyodide-wheels
-          path: pyodide
       - uses: softprops/action-gh-release@v3
         with:
           name: v${{ needs.release_check.outputs.tag }}
           tag_name: v${{ needs.release_check.outputs.tag }}
           target_commitish: ${{ github.ref_name }}
           generate_release_notes: true
-          files: pyodide/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,24 @@ jobs:
           name: wheel-${{ matrix.py }}-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
+  pyodide:
+    needs: release_check
+    name: pyodide
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - uses: pypa/cibuildwheel@v4.2
+        env:
+          CIBW_PLATFORM: pyodide
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pyodide-wheels
+          path: ./wheelhouse/*.whl
+
   sdist:
     needs: release_check
     name: source package
@@ -99,7 +117,7 @@ jobs:
 
   upload:
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [wheels, sdist]
+    needs: [wheels, pyodide, sdist]
     runs-on: ubuntu-latest
 
     environment:
@@ -111,9 +129,10 @@ jobs:
       attestations: write
 
     steps:
+      # pyodide wheels are not accepted by PyPI; they go on the GitHub release
       - uses: actions/download-artifact@v8
         with:
-          pattern: "*"
+          pattern: "{sdist,wheel-*}"
           merge-multiple: true
           path: dist
 
@@ -130,9 +149,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: pyodide-wheels
+          path: pyodide
       - uses: softprops/action-gh-release@v3
         with:
           name: v${{ needs.release_check.outputs.tag }}
           tag_name: v${{ needs.release_check.outputs.tag }}
           target_commitish: ${{ github.ref_name }}
           generate_release_notes: true
+          files: pyodide/*.whl

--- a/src/fcn.cpp
+++ b/src/fcn.cpp
@@ -29,11 +29,11 @@ std::vector<double> flatten_hessian(py::array_t<double> arg) {
 
   // flatten the matrix
   auto r = arg.unchecked<2>();
-  const unsigned size = arg.shape(0);
+  const py::ssize_t size = arg.shape(0);
   if (arg.shape(1) != size) throw std::runtime_error("2D matrix is not square");
   std::vector<double> result(size * size);
-  for (unsigned i = 0; i < size; ++i)
-    for (unsigned j = 0; j < size; ++j) result[i * size + j] = r(i, j);
+  for (py::ssize_t i = 0; i < size; ++i)
+    for (py::ssize_t j = 0; j < size; ++j) result[i * size + j] = r(i, j);
   return result;
 }
 

--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1775,10 +1775,11 @@ def is_positive_definite(m: ArrayLike) -> bool:
         # maybe check this first https://en.wikipedia.org/wiki/Diagonally_dominant_matrix
         # and only try cholesky if that fails
         try:
-            np.linalg.cholesky(m)
+            ll = np.linalg.cholesky(m)
         except np.linalg.LinAlgError:
             return False
-        return True
+        # some LAPACK builds (e.g. pyodide) return NaN instead of raising
+        return bool(np.all(np.isfinite(ll)))
     return False
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds `cp313`, `cp314`, and `cp315` pyodide (wasm32) wheel jobs to the release workflow, built with cibuildwheel and tested in node. The wheels are uploaded to PyPI with the others.

Two small source fixes were needed for wasm32: a sign-compare error in `flatten_hessian`, and `is_positive_definite` now handles a NaN result from cholesky, since pyodide's numpy returns NaN instead of raising.