### PR TITLE
ci: build iOS wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,9 +114,6 @@ jobs:
 
       - uses: astral-sh/setup-uv@v10.0.1
 
-      # the preinstalled cmake cannot cross-compile to iOS
-      - run: brew uninstall cmake; brew install cmake
-
       - uses: pypa/cibuildwheel@v4.2
         env:
           CIBW_PLATFORM: ios

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,34 @@ jobs:
           name: wheel-${{ matrix.py }}-pyodide
           path: ./wheelhouse/*.whl
 
+  ios:
+    needs: release_check
+    name: ${{ matrix.os }} ios
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-26-intel]
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - uses: astral-sh/setup-uv@v10.0.1
+
+      # the preinstalled cmake cannot cross-compile to iOS
+      - run: brew uninstall cmake; brew install cmake
+
+      - uses: pypa/cibuildwheel@v4.2
+        env:
+          CIBW_PLATFORM: ios
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheel-ios-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
   sdist:
     needs: release_check
     name: source package
@@ -124,7 +152,7 @@ jobs:
 
   upload:
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [wheels, pyodide, sdist]
+    needs: [wheels, pyodide, ios, sdist]
     runs-on: ubuntu-latest
 
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ skip = [
     "cp39-musllinux_i686", # no numpy wheel
     "*t-win32",            # no numpy wheel
 ]
+test-skip = ["*-ios_*"] # no simulator device on CI
 test-requires = "pytest"
 test-command = "python -m pytest {package}/tests"
 
@@ -162,6 +163,18 @@ test-command = "python -m pytest {package}/tests"
 # this makes sure that we build only on platforms that have a corresponding numpy wheel
 UV_ONLY_BINARY = ":all:"
 PIP_ONLY_BINARY = ":all:"
+
+[tool.cibuildwheel.ios]
+build-frontend = "build"
+xbuild-tools = ["cmake", "ninja"]
+test-sources = ["tests"]
+test-command = "python -m pytest tests"
+
+[tool.cibuildwheel.ios.environment]
+UV_ONLY_BINARY = ":all:"
+PIP_ONLY_BINARY = ":all:"
+# beeware hosts the iOS wheels for numpy
+PIP_EXTRA_INDEX_URL = "https://pypi.anaconda.org/beeware/simple/"
 
 [[tool.cibuildwheel.overrides]]
 # to match numpy, we use manylinux2014 for cp310 (and 3.9, since manylinux2010 is dead)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds an `ios` job to the release workflow that cross-compiles wheels from both `macos-latest` and `macos-26-intel`, and includes them in the PyPI upload.

The `[tool.cibuildwheel.ios]` table uses the plain `build` frontend, declares `cmake` and `ninja` as `xbuild-tools`, and adds the beeware index, which supplies the iOS numpy wheels. Its environment table repeats the `*_ONLY_BINARY` settings because a platform table replaces the top-level one instead of merging it. The preinstalled Homebrew cmake cannot cross-compile to iOS, so the job reinstalls it.

Tests are skipped for iOS: CI has no simulator device.

Modelled on the equivalent job in boost-histogram.