### PR TITLE
perf: use identity check before copying the parameter state

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1008,7 +1008,7 @@ class Minuit:
             ncall = self._migrad_maxcall()
         nstep = max(2, int(ncall ** (1 / n)))
 
-        if self._last_state == self._init_state:
+        if self._last_state is self._init_state:
             # avoid overriding initial state
             self._last_state = MnUserParameterState(self._last_state)
 
@@ -2548,7 +2548,7 @@ class Minuit:
         #
         # If FunctionMinimum does not exist, we don't want to copy. We want to
         # implicitly modify _init_state; _last_state is an alias for _init_state, then.
-        if self._fmin and self._last_state == self._fmin._src.state:
+        if self._fmin and self._last_state is self._fmin._src.state:
             self._last_state = MnUserParameterState(self._last_state)
 
     def _make_covariance(self) -> None:

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1898,6 +1898,40 @@ def test_fixto_does_not_mutate_fmin():
     assert m._fmin_does_not_exist_or_last_state_was_modified()
 
 
+@pytest.mark.parametrize(
+    "attr,value",
+    (
+        ("values", 1.0),
+        ("errors", 3.0),
+        ("fixed", True),
+        ("limits", (-10, 10)),
+    ),
+)
+def test_modification_does_not_mutate_fmin(attr, value):
+    m = Minuit(func0, x=0, y=0)
+    m.migrad()
+
+    # _last_state is a reference to the FunctionMinimum state until it is modified
+    assert m._last_state is m._fmin._src.state
+    fmin = m.fmin
+    state_before = [(p.value, p.error, p.is_fixed) for p in m._fmin._src.state]
+
+    getattr(m, attr)["x"] = value
+
+    assert m._last_state is not m._fmin._src.state
+    assert m.fmin is fmin
+    assert [(p.value, p.error, p.is_fixed) for p in m._fmin._src.state] == state_before
+
+
+def test_scan_does_not_mutate_init_state():
+    m = Minuit(func0, x=0, y=0)
+    m.limits = (-10, 10)
+    init_params = m.init_params
+    m.scan(ncall=20)
+    assert m.init_params == init_params
+    assert m.values != [p.value for p in init_params]
+
+
 def test_reset_resets_all_counters():
     m = Minuit(func0, grad=func0_grad, x=0, y=0)
     m.migrad()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit._copy_state_if_needed` and `Minuit.scan` compared `_last_state` with the `FunctionMinimum` state by value. That runs the C++ `MnUserParameterState::operator==`, which inverts the covariance matrix to compare global correlations. It cost 0.45 ms per parameter assignment at 100 parameters when the two states were equal, which is the case for the first assignment after each fit.

`_last_state` is an alias of the `FunctionMinimum` state until it is modified, and an alias of `_init_state` before the first fit. An identity check is the intended semantics; `_fmin_does_not_exist_or_last_state_was_modified` already uses one.

Two regression tests check that assignments to `values`, `errors`, `fixed`, and `limits` do not mutate the `FunctionMinimum` state, and that `scan` does not mutate the initial state.
