### PR TITLE
perf: do not sort in _unbinned_nll

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -164,8 +164,9 @@ def log_or_zero(x):
 
 
 def _unbinned_nll(x):
-    # sorting makes sum more accurate, protect against x = 0
-    return -np.sum(np.sort(np.log(x + _TINY_FLOAT)))
+    # adding tiny protects against x = 0; np.sum sums pairwise, which is accurate
+    # enough that pre-sorting is not worth its cost
+    return -np.sum(np.log(x + _TINY_FLOAT))
 
 
 def _z_squared(y, ye, ym):
@@ -445,14 +446,8 @@ try:
     def _ol_z_squared(y, ye, ym):
         return _z_squared  # pragma: no cover
 
-    _unbinned_nll_np = _unbinned_nll
-    _unbinned_nll_nb = jit(_unbinned_nll_np)
-
-    def _unbinned_nll(x):
-        if x.dtype in (np.float32, np.float64):
-            return _unbinned_nll_nb(x)
-        # fallback to numpy for float128
-        return _unbinned_nll_np(x)
+    # _unbinned_nll is not jitted: numba's naive sum is both slower and less accurate
+    # than the pairwise sum of np.sum.
 
     _multinomial_chi2_np = multinomial_chi2
     _multinomial_chi2_nb = jit(_multinomial_chi2_np)

--- a/tests/test_without_numba.py
+++ b/tests/test_without_numba.py
@@ -15,7 +15,6 @@ def npa(*args, **kwargs):
     (
         ("log_or_zero", (npa(1.2, 0),)),
         ("_z_squared", (npa(1.2, 0), npa(1.2, 1.0), npa(1.2, 1))),
-        ("_unbinned_nll", (npa(1.2, 0),)),
         ("multinomial_chi2", (npa(1, 0), npa(1.2, 0))),
         ("chi2", (npa(1.2, 0), npa(1.2, 1.0), npa(1.2, 0.1))),
         ("poisson_chi2", (npa(1, 0), npa(1.2, 0.1))),


### PR DESCRIPTION
This is a lot faster, but it is a significant change - sorting + pairwise is costly but drops the "more accurate" note. Needs further study, maybe it can be optional, etc. I'd rather expect a numba implementation possibly could use a more advanced summing algorithm (like `math.fsum`) instead of sorting?

Edit: keeping this in draft till after the next release, when it can be revisited.

:robot: _AI text below_ :robot:

`_unbinned_nll` sorted the log values before the sum, and with numba installed it dispatched to a jitted copy of the same code. Measurements against a `longdouble` reference show that the numba + sort path was the slowest option at every size and not more accurate than the plain `np.sum`, which uses pairwise summation.

| N | numpy + sort | numpy | numba + sort (old path) |
|---|---|---|---|
| 1e3 | 0.016 ms | 0.003 ms | 0.010 ms |
| 1e5 | 2.5 ms | 0.34 ms | 5.1 ms |
| 1e6 | 29 ms | 3.6 ms | 62 ms |

`UnbinnedNLL.__call__` with 200k points goes from 10.9 ms to 0.8 ms. The jitted variant is removed. There is now one implementation, so the numba/numpy parity test for this function is dropped.
