### PR TITLE
fix: pass a valid Python version to the maxtest nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ ENV = {
 
 PYPROJECT = nox.project.load_toml("pyproject.toml")
 MINIMUM_PYTHON = PYPROJECT["project"]["requires-python"].strip(">=")
-LATEST_PYTHON = str(python_releases.latest())
+LATEST_PYTHON = python_releases.latest_str()
 DEPS = {g: nox.project.dependency_groups(PYPROJECT, g) for g in ("test", "dev")}
 
 nox.options.sessions = ["test", "mintest", "maxtest"]

--- a/python_releases.py
+++ b/python_releases.py
@@ -26,7 +26,8 @@ class PythonVersionParser(HTMLParser):
         """Extract Python version from entry."""
         if self.found_version:
             self.found_version = False
-            match = re.search(r"Python (\d+)\.(\d+)\.(\d+)?", data)
+            # negative lookahead excludes pre-releases like "3.15.0rc2"
+            match = re.search(r"Python (\d+)\.(\d+)\.(\d+)(?!\w)", data)
             if match:
                 major = int(match.group(1))
                 minor = int(match.group(2))
@@ -54,6 +55,12 @@ def versions():
 def latest():
     """Return version of latest Python release."""
     return max(versions())
+
+
+def latest_str():
+    """Return 'major.minor' string of the latest Python release."""
+    major, minor, _ = latest()
+    return f"{major}.{minor}"
 
 
 def main():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`python_releases.latest()` returns a tuple since abff499, so `nox -s maxtest` asked uv for Python `"(3, 14, 7)"` and the session could not run.

Add `latest_str()`, which returns `"major.minor"`, and use it in the noxfile. The release parser now also rejects pre-release strings such as `3.15.0rc2`.
