### PR TITLE
ci: do not clone the full ROOT history

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,6 @@ jobs:
     - uses: actions/checkout@v7
       with:
         submodules: true
-        fetch-depth: 0  # needed to get correct ROOT version
     # must come after checkout
     - uses: hendrikmuhs/ccache-action@v1.2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          submodules: true
           fetch-depth: 0
       - uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The docs workflow used `fetch-depth: 0` together with `submodules: true`. That clones the full ROOT history, about 1.5 GB, on every run. The comment said this was needed for the ROOT version, but `doc/conf.py` stores the version as a string since b18cee3.

The release check job needs the tags but not the submodule, so `submodules: true` is removed there.
