### PR TITLE
ci: set permissions, timeouts, and concurrency groups

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,12 +25,16 @@ on:
       - .github/workflows/coverage.yml
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 env:
   CMAKE_ARGS: -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -19,6 +22,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v7
       with:
@@ -53,6 +57,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
     - uses: actions/configure-pages@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   # Latest Jupyter requires this to acknowledge deprecation
   JUPYTER_PLATFORM_DIRS: 1
@@ -21,6 +24,7 @@ env:
 jobs:
   release_check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -44,6 +48,7 @@ jobs:
     needs: release_check
     name: ${{ matrix.py }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +82,7 @@ jobs:
     needs: release_check
     name: ${{ matrix.py }} pyodide
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +108,7 @@ jobs:
     needs: release_check
     name: ${{ matrix.os }} ios
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -127,6 +134,7 @@ jobs:
     needs: release_check
     name: source package
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -151,14 +159,15 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: [wheels, pyodide, ios, sdist]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     environment:
       name: pypi
       url: https://pypi.org/project/iminuit/
 
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write  # trusted publishing to PyPI, PEP 740 attestations
+      attestations: write  # actions/attest-build-provenance
 
     steps:
       - uses: actions/download-artifact@v8
@@ -178,6 +187,11 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: [release_check, upload]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write  # create the GitHub release
+
     steps:
       - uses: actions/checkout@v7
       - uses: softprops/action-gh-release@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
       - CMakeLists.txt
       - .github/workflows/test.yml
 
+permissions:
+  contents: read
+
 env:
   CMAKE_ARGS: -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
   # Latest Jupyter requires this to acknowledge deprecation
@@ -18,6 +21,7 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       matrix:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

- Add a top-level `permissions: contents: read` to all workflows. Only the job that creates the GitHub release gets `contents: write`. Pull request jobs no longer run with a write token.
- Add `timeout-minutes` to every job.
- Use `head_ref || run_id` in the concurrency groups of the coverage and docs workflows. `head_ref` is empty on push events, so all pushes shared one group and cancelled each other.
