### PR TITLE
ci: use uv in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v10.0.1
 
-      - run: pipx run build --sdist
+      - run: uv build --sdist
 
       - run: uv pip install --system pytest
       - run: uv pip install --system -v $(echo dist/iminuit-*)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,11 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          pip install packaging
+          uv pip install --system packaging
           python .ci/release_check.py
 
       - id: tag
@@ -135,11 +136,12 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - run: pipx run build --sdist
 
-      - run: python -m pip install --upgrade pip setuptools pytest
-      - run: python -m pip install -v $(echo dist/iminuit-*)
+      - run: uv pip install --system pytest
+      - run: uv pip install --system -v $(echo dist/iminuit-*)
       - run: python -m pytest
 
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The release check and sdist jobs used pip while the other workflows use uv. Switch them to `uv pip install --system` and drop `setuptools`, which scikit-build-core does not need.
