### PR TITLE
fix: install the notebook dependencies on Binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,1 @@
-python -m pip install iminuit[test]
+python -m pip install iminuit --group notebook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,24 +36,28 @@ repository = "https://github.com/scikit-hep/iminuit"
 documentation = "https://scikit-hep.org/iminuit"
 
 [dependency-groups]
-test = [
-    "coverage",
+# Packages that the tutorial notebooks import; also used on Binder
+notebook = [
+    "boost_histogram",
     "ipywidgets",
-    "ipykernel; platform_python_implementation=='CPython'",
-    "PySide6; platform_python_implementation=='CPython'",
-    "joblib",
     "jacobi",
+    "joblib",
     "matplotlib; platform_python_implementation=='CPython'",
     "numba; platform_python_implementation=='CPython'",
     "numba-stats; platform_python_implementation=='CPython'",
+    "resample; platform_python_implementation=='CPython'",
+    "scipy; platform_python_implementation=='CPython'",
+    "tabulate",
+]
+test = [
+    { include-group = "notebook" },
+    "coverage",
+    "ipykernel; platform_python_implementation=='CPython'",
+    "PySide6; platform_python_implementation=='CPython'",
     "pytest",
     "pytest-xdist",
     "pytest-xvfb",
     "pytest-qt; platform_python_implementation=='CPython'",
-    "scipy; platform_python_implementation=='CPython'",
-    "tabulate",
-    "boost_histogram",
-    "resample; platform_python_implementation=='CPython'",
     "unicodeitplus",
     "pydantic",
     "annotated_types",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`binder/postBuild` installed `iminuit[test]`. The project has no extras since the test dependencies moved to a dependency group, so pip ignored the extra and the Binder tutorials lacked matplotlib, scipy, and numba.

This adds a `notebook` dependency group with the packages that the notebooks import, includes it in the `test` group, and installs it on Binder with `pip install --group`. The Binder image (repo2docker 2026.4.x) has pip 25.2, which supports `--group`. `uv.lock` is unchanged by the regrouping.