### PR TITLE
chore: list both licenses in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -75,4 +75,4 @@ keywords:
   - statistics
   - data analysis
   - Scikit-HEP
-license: MIT
+license: [MIT, LGPL-2.1-or-later]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`pyproject.toml` declares `MIT AND LGPL-2.1-or-later` because Minuit2 is LGPL. `CITATION.cff` said MIT only. Validated with `cffconvert --validate`.
