### PR TITLE
docs: remove duplicated nbsphinx settings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,12 +74,6 @@ html_static_path = ["_static"]
 
 html_theme = "sphinx_rtd_theme"
 
-nbsphinx_kernel_name = "python3"
-nbsphinx_execute_arguments = [
-    "--InlineBackend.figure_formats={'svg', 'pdf'}",
-    "--InlineBackend.rc=figure.dpi=96",
-]
-
 linkcheck_timeout = 10
 linkcheck_allow_unauthorized = True
 linkcheck_report_timeouts_as_broken = False


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`nbsphinx_kernel_name` and `nbsphinx_execute_arguments` were defined twice in `doc/conf.py` with the same values.
