### PR TITLE
fix: `log_or_zero` helper mistakenly downcasts integers to floats when the input is of integer dtype

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -157,9 +157,8 @@ def log_or_zero(x):
         Elementwise contains log(x) for x > 0 and zero otherwise.
     """
     # return 0 for x <= 0
-    # x * 1.0 promotes integer input to float; np.zeros_like(x) alone would
-    # inherit an integer dtype from x and truncate the logarithm, while
-    # dtype=np.float64 would downcast extended precision such as float128
+    # integers truncate the logarithm; x * 1.0 promotes integer input
+    # to float but keeps the precision and works in numba.
     r = np.zeros_like(x * 1.0)
     ma = x > 0
     r[ma] = np.log(x[ma])

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -157,7 +157,10 @@ def log_or_zero(x):
         Elementwise contains log(x) for x > 0 and zero otherwise.
     """
     # return 0 for x <= 0
-    r = np.zeros_like(x)
+    # x * 1.0 promotes integer input to float; np.zeros_like(x) alone would
+    # inherit an integer dtype from x and truncate the logarithm, while
+    # dtype=np.float64 would downcast extended precision such as float128
+    r = np.zeros_like(x * 1.0)
     ma = x > 0
     r[ma] = np.log(x[ma])
     return r


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/iminuit/issues/1190

The line `r[ma] = np.log(x[ma])` effectively down casts floats to ints if `r` is of integer dtype meaning that `r` should be constructed with a floating dtype but it accidentally inherited `x`'s dtype which might be integer as it was constructed with `np.zeros_like(x)`. We now just construct it as `np.zeros_like(x * 1.0)`. This was the simplest solution. See the comment in the code for the reason.