### PR TITLE
fix: return user callables from Minuit.g2 and Minuit.hessian

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -86,14 +86,14 @@ class Minuit:
         return self._fcn.gradient  # type:ignore
 
     @property
-    def g2(self) -> Callable[[np.ndarray], np.ndarray]:
-        """Get g2 function of the cost function."""
-        return self._fcn.g2  # type:ignore
+    def g2(self) -> Optional[Callable[[np.ndarray], np.ndarray]]:
+        """Get user-provided second derivative function, or None if not set."""
+        return self._fcn._g2  # type:ignore
 
     @property
-    def hessian(self) -> Callable[[np.ndarray], np.ndarray]:
-        """Get hessian function of the cost function."""
-        return self._fcn.hessian  # type:ignore
+    def hessian(self) -> Optional[Callable[[np.ndarray], np.ndarray]]:
+        """Get user-provided Hessian function, or None if not set."""
+        return self._fcn._hessian  # type:ignore
 
     @property
     def pos2var(self) -> Tuple[str, ...]:

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1009,6 +1009,20 @@ def test_grad():
     assert_equal(g, func0_grad(2.0, 5.0))
 
 
+def test_g2_and_hessian():
+    m = Minuit(func0, grad=func0_grad, g2=func0_g2, x=0, y=0)
+    assert m.g2 is func0_g2
+    assert_equal(m.g2(2.0, 5.0), func0_g2(2.0, 5.0))
+
+    m = Minuit(func0, grad=func0_grad, hessian=func0_hessian, x=0, y=0)
+    assert m.hessian is func0_hessian
+    assert_equal(m.hessian(2.0, 5.0), func0_hessian(2.0, 5.0))
+
+    m = Minuit(func0, x=0, y=0)
+    assert m.g2 is None
+    assert m.hessian is None
+
+
 def test_values(minuit):
     expected = [2.0, 5.0]
     assert len(minuit.values) == 2


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The properties `Minuit.g2` and `Minuit.hessian` accessed `self._fcn.g2` and `self._fcn.hessian`. These attributes do not exist on the C++ `FCN` class. For example, `Minuit(f, x=1, g2=g2fn).g2` raised `AttributeError: 'iminuit._core.FCN' object has no attribute 'g2'`. The fix reads the correct read-only attributes `_g2` and `_hessian` instead, and returns `None` when the user did not supply a callable. No C++ changes were needed.

Part of #1192