### PR TITLE
fix: import PySide6 before matplotlib's Qt backend in qtwidget

### DIFF
--- a/src/iminuit/qtwidget.py
+++ b/src/iminuit/qtwidget.py
@@ -8,11 +8,16 @@ from contextlib import contextmanager
 
 try:
     from matplotlib import pyplot as plt
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+
+    # PySide6 must be imported before any matplotlib Qt backend: importing
+    # backend_qt5agg first makes matplotlib.backends.qt_compat only look for
+    # PyQt5/PySide2, so it fails to find an already-installed PySide6.
     from PySide6 import QtCore, QtGui, QtWidgets
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 except ImportError as e:
-    # Not only ModuleNotFoundError: if no Qt binding at all is installed,
-    # matplotlib.backends.qt_compat raises a plain ImportError.
+    # Not only ModuleNotFoundError: matplotlib.backends.qt_compat can also
+    # raise a plain ImportError, e.g. if PySide6 fails to load for other
+    # reasons than being absent.
     e.msg += (
         "\n\nPlease install PySide6, and matplotlib to enable interactive "
         "outside of Jupyter notebooks."

--- a/tests/test_qtwidget.py
+++ b/tests/test_qtwidget.py
@@ -2,6 +2,8 @@ import pytest
 from iminuit import Minuit
 from numpy.testing import assert_allclose
 import contextlib
+import subprocess
+import sys
 
 mpl = pytest.importorskip("matplotlib")
 plt = pytest.importorskip("matplotlib.pyplot")
@@ -144,3 +146,17 @@ def test_interactive_pyside6_with_array_func(qtbot):
 
     qtinteractive(qtbot, m, trace_args)
     assert trace_args.nargs > 0
+
+
+def test_import_in_fresh_process():
+    # regression test: importing backend_qt5agg before PySide6 forces
+    # matplotlib to look only for PyQt5/PySide2, so a process that only has
+    # PySide6 installed and never imported PySide6 before iminuit.qtwidget
+    # fails with "Failed to import any of the following Qt binding modules:
+    # PyQt5, PySide2"
+    result = subprocess.run(
+        [sys.executable, "-c", "import iminuit.qtwidget"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`src/iminuit/qtwidget.py` imported `matplotlib.backends.backend_qt5agg` before `PySide6`. That module forces matplotlib to look only for PyQt5 or PySide2, so `import iminuit.qtwidget` fails with `ImportError: Failed to import any of the following Qt binding modules: PyQt5, PySide2` in a fresh process where only PySide6 is installed. `Minuit(...).interactive()` from a plain script broke this way, even though tests passed because pytest-qt imports PySide6 first. The fix imports PySide6 first, then the version-agnostic `matplotlib.backends.backend_qtagg`. Also corrected a comment that misattributed the plain-`ImportError` case to a missing Qt binding.

Part of #1192