### PR TITLE
fix: keep annotations when merging signatures

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1152,7 +1152,11 @@ def merge_signatures(
         amap = []
         for k, ann in describe(f, annotations=True).items():
             if k in args:
-                amap.append(args.index(k))
+                i = args.index(k)
+                amap.append(i)
+                # an annotation from a later callable fills a missing one
+                if anns[i] is None:
+                    anns[i] = ann
             else:
                 amap.append(len(args))
                 args.append(k)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -449,6 +449,18 @@ def test_UnbinnedNLL_annotated():
     assert m.limits[1] == (0, np.inf)
 
 
+@pytest.mark.parametrize("reverse", (False, True))
+def test_CostSum_annotated(reverse):
+    nll = UnbinnedNLL([], annotated_pdf)
+    nc = NormalConstraint("sigma", 1.0, 0.1)
+    c = nc + nll if reverse else nll + nc
+
+    assert describe(c, annotations=True) == {"mu": None, "sigma": (0, np.inf)}
+
+    m = Minuit(c, mu=0, sigma=1)
+    assert m.limits["sigma"] == (0, np.inf)
+
+
 @pytest.mark.parametrize("verbose", (0, 1))
 @pytest.mark.parametrize("model", (logpdf, pdf))
 @pytest.mark.parametrize("use_grad", (False, True))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,6 +9,7 @@ from iminuit._optional_dependencies import optional_module_for
 import pickle
 from iminuit._hide_modules import hide_modules
 from iminuit.util import is_module_available
+from iminuit.typing import Annotated, Gt, Lt
 
 
 def test_ndim():
@@ -591,6 +592,20 @@ def test_merge_signatures():
     assert args == ["x", "y", "z", "a", "b"]
     assert pf == [0, 1, 2]
     assert pg == [0, 3, 4]
+
+
+def test_merge_signatures_annotations():
+    def f(x, y: Annotated[float, Gt(0)]):
+        return x + y
+
+    def g(x: Annotated[float, Lt(0)], y):
+        return x + y
+
+    anns, _ = util.merge_signatures([f, g], annotations=True)
+    assert anns == {"x": (-np.inf, 0), "y": (0, np.inf)}
+
+    anns, _ = util.merge_signatures([g, f], annotations=True)
+    assert anns == {"x": (-np.inf, 0), "y": (0, np.inf)}
 
 
 def test_propagate_1():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`merge_signatures(..., annotations=True)` kept the annotation of the first callable that mentioned a parameter name. If that first annotation was `None`, a real annotation from a later callable was lost. With `nll = UnbinnedNLL(data, pdf)` where `pdf` annotates `sigma` as positive, and `nc = NormalConstraint("sigma", 1.0, 0.1)`, `describe(nll + nc, annotations=True)` gave the limit for `sigma` but `describe(nc + nll, annotations=True)` gave `None`, so `Minuit(nc + nll, ...)` had no limit on `sigma`.

Now a later non-`None` annotation fills a stored `None`. Two conflicting non-`None` annotations still keep the first one.

Part of #1192