### PR TITLE
fix: handle keyword-only and odd annotations in describe

### DIFF
--- a/src/iminuit/util.py
+++ b/src/iminuit/util.py
@@ -1266,6 +1266,11 @@ def describe(callable, *, annotations=False):
         def fcn(a, b, c=1): ...
         # describe returns [a, b, c];
         # positional arguments with default values are detected
+
+        def fcn(a, b, *, c=1): ...
+        # describe returns [a, b];
+        # keyword-only arguments are ignored, since the function is called
+        # with positional arguments only
     """
     if _address_of_cfunc(callable) != 0:
         return {} if annotations else []
@@ -1305,6 +1310,9 @@ def _describe_impl_inspect(callable):
             break
         # stop when keyword argument is encountered
         if par.kind is inspect.Parameter.VAR_KEYWORD:
+            break
+        # stop at keyword-only arguments, the FCN calls the function positionally
+        if par.kind is inspect.Parameter.KEYWORD_ONLY:
             break
         r[name] = _get_limit(par.annotation)
     return r
@@ -1396,8 +1404,8 @@ def _get_limit(
         # have a lot of problems, see https://peps.python.org/pep-0649.
         try:
             annotation = eval(annotation, None, typing.__dict__)
-        except NameError:
-            # We ignore unknown annotations to fix issue #846.
+        except Exception:
+            # We ignore annotations that cannot be evaluated to fix issue #846.
             # I cannot replicate here what inspect.signature(..., eval_str=True) does.
             # I need a dict with the global objects at the call site of describe, but
             # it is not globals(). Anyway, when using strings, only the annotations
@@ -1421,7 +1429,7 @@ def _get_limit(
             if c.stop is not None:
                 upper = c.stop
             continue
-        if isinstance(c, Sequence):
+        if isinstance(c, Sequence) and not isinstance(c, (str, bytes)):
             lower, upper = c
             continue
 

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -120,7 +120,7 @@ def test_decorated_function():
 
     assert describe(one_arg) == list("x")
     assert describe(many_arg) == list("xyzt")
-    assert describe(kw_only) == list("xyz")
+    assert describe(kw_only) == list("x")
 
 
 def test_ambiguous_1():
@@ -308,3 +308,32 @@ def test_string_annotation_3():
         pass
 
     assert describe(f, annotations=True) == {"x": None, "mu": None}
+
+
+def test_string_annotation_4():
+    # annotation that raises something other than NameError when evaluated;
+    # np.float_ was removed in numpy-2
+    def f(x, mu: "np.float_"):
+        pass
+
+    assert describe(f, annotations=True) == {"x": None, "mu": None}
+
+
+def test_annotation_with_string_metadata():
+    # a str is a Sequence, but it is not a limit
+    def f(x: Annotated[float, "units: meters"], y: Annotated[float, "ab"]):  # noqa: F821
+        pass
+
+    # no constraint found, limits are infinite
+    assert describe(f, annotations=True) == {
+        "x": (-np.inf, np.inf),
+        "y": (-np.inf, np.inf),
+    }
+
+
+def test_keyword_only():
+    def f(x, *, y=1):
+        pass
+
+    assert describe(f) == ["x"]
+    assert describe(f, annotations=True) == {"x": None}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`describe()` reported keyword-only parameters as fit parameters. For `def f(x, *, y=1)` it returned `["x", "y"]`, and `Minuit(f, x=1, y=1).migrad()` then failed with `TypeError: f() takes 1 positional argument but 2 were given`, because the FCN calls the cost function positionally. The signature loop now stops at keyword-only parameters, like it does for `*args` and `**kwargs`.

`_get_limit` treated any `Sequence` in `Annotated` metadata as a limit pair. Since `str` is a Sequence, `Annotated[float, "units: meters"]` raised `ValueError: too many values to unpack` and `Annotated[float, "ab"]` gave the limits `("a", "b")`. String metadata is now ignored.

`_get_limit` also caught only `NameError` when it evaluates a string annotation. `x: "np.float_"` raises `AttributeError` with numpy-2, and on Python 3.9 `x: "float | None"` raises `TypeError`, so `describe()` and `Minuit()` failed. All exceptions from the evaluation are now ignored, as the comment about issue #846 intends.

Part of #1192