### PR TITLE
fix: use eigh for the symmetric covariance block in mncontour

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2677,12 +2677,18 @@ class Minuit:
 
         center = self.values[[ix, iy]]
         assert self.covariance is not None
-        t, u = np.linalg.eig(
+        # the covariance block is symmetric, so eigh gives real eigenvalues;
+        # eig would return complex128 even for real symmetric input (numpy >= 2.5).
+        # eigh sorts ascending, reverse to descending to keep the phase of the
+        # phi parametrization below stable under the discrete size grid
+        t, u = np.linalg.eigh(
             [
                 [self.covariance[ix, ix], self.covariance[ix, iy]],
                 [self.covariance[ix, iy], self.covariance[iy, iy]],
             ]
         )
+        t = t[::-1]
+        u = u[:, ::-1]
         s = (t * factor) ** 0.5
 
         # strategy 0 to avoid expensive computation of Hesse matrix

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1,5 +1,6 @@
 # type:ignore
 import platform
+import warnings
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -716,6 +717,22 @@ def test_mncontour(grad, cl, experimental):
     x, y = m.values
     assert_allclose((x + xm.lower, y + ym.lower), cmin, atol=1e-2)
     assert_allclose((x + xm.upper, y + ym.upper), cmax, atol=1e-2)
+
+
+def test_mncontour_experimental_real_dtype():
+    # np.linalg.eig returns complex dtype even for symmetric input on
+    # numpy >= 2.5; the covariance block here is symmetric, so eigh
+    # (real dtype) must be used instead
+    pytest.importorskip("scipy.optimize")
+
+    m = Minuit(func0, x=1.0, y=2.0)
+    m.migrad()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        pts = m.mncontour("x", "y", size=10, experimental=True)
+    pts = np.asarray(pts)
+    assert pts.dtype.kind == "f"
+    assert np.all(np.isfinite(pts))
 
 
 @pytest.mark.parametrize("experimental", (False, True))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit._experimental_mncontour` used `np.linalg.eig` on a symmetric 2x2 covariance block. numpy 2.5 changed `eig` to always return complex arrays, even for real symmetric input. This made `m.mncontour("x", "y", experimental=True)` return complex128 contour points, which triggers a `ComplexWarning` in `draw_mncontour`, or a `TypeError` in `MnUserParameterState.set_value` when warnings are errors. The fix uses `eigh`, which returns real eigenvalues for symmetric input, and reverses its ascending order to descending so the sampled contour points stay the same as before.

Part of #1192