### PR TITLE
fix: keep the minimum usable after pickle or deepcopy

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -2596,6 +2596,16 @@ class Minuit:
     def _fmin_does_not_exist_or_last_state_was_modified(self) -> bool:
         return not self._fmin or self._fmin._src.state is not self._last_state
 
+    def __setstate__(self, state: Tuple[Any, Dict[str, Any]]) -> None:
+        """Restore a pickled or copied instance."""
+        for k, v in state[1].items():
+            setattr(self, k, v)
+        # Copying breaks the identity of _last_state and the state inside the
+        # FunctionMinimum, which is how a user modification is detected. Restore it,
+        # so that hesse() and minos() can still reuse the existing minimum.
+        if self._fmin and self._fmin._src.state == self._last_state:
+            self._last_state = self._fmin._src.state
+
     def __repr__(self):
         """Get detailed text representation."""
         s = []

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1690,6 +1690,42 @@ def test_pickle(grad):
     assert m2.fmin.ngrad == m.fmin.ngrad
 
 
+def func_simple(x, y):
+    return (x - 1) ** 2 + (y - 2) ** 2
+
+
+@pytest.mark.parametrize("copy_fn", ("pickle", "deepcopy"))
+def test_pickle_reuses_minimum(copy_fn):
+    import pickle
+    import copy
+
+    m = Minuit(func_simple, x=0, y=0)
+    m.migrad()
+
+    if copy_fn == "pickle":
+        m2 = pickle.loads(pickle.dumps(m))
+    else:
+        m2 = copy.deepcopy(m)
+
+    # the copy must see its own minimum state, not an equal-but-distinct copy
+    assert m2._last_state is m2._fmin._src.state
+
+    n1 = m.fmin.nfcn
+    n2 = m2.fmin.nfcn
+
+    m.hesse()
+    m2.hesse()
+
+    # hesse must not restart the minimization on the copy
+    assert m2.fmin.algorithm == "Migrad"
+    assert m2.fmin.nfcn - n2 == m.fmin.nfcn - n1
+
+    # modifying the copy still does not change the stored minimum
+    m2.values["x"] = 3
+    assert m2._last_state is not m2._fmin._src.state
+    assert m2._fmin._src.state[0].value == approx(1, abs=1e-3)
+
+
 def test_minos_new_min():
     xref = [1.0]
     m = Minuit(lambda x: (x - xref[0]) ** 2, x=0)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit` finds user modifications by comparing the identity of `_last_state` with the state in the `FunctionMinimum`. `pickle.loads(pickle.dumps(m))` and `copy.deepcopy(m)` make two states that are equal but not identical, so the copy looked modified. For `f(x, y) = (x - 1)**2 + (y - 2)**2`, `hesse()` on the copy then used 23 function calls instead of 10, set `fmin.algorithm` to `"External"`, and reset `fmin.time`.

`__setstate__` now re-binds `_last_state` to the state of the `FunctionMinimum` if the two are still equal by value. Copies of a modified object keep separate states, so `_copy_state_if_needed` still protects the stored minimum.

Part of #1192