### PR TITLE
fix: clear stale Minos errors and refresh covariance

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -155,6 +155,10 @@ class Minuit:
         self._fcn._errordef = value
         if self._fmin:
             self._fmin._src.errordef = value
+            # Minuit2 rescaled the errors in the user state, refresh our copy of the
+            # covariance matrix, unless the user already modified the state.
+            if self._last_state is self._fmin._src.state:
+                self._make_covariance()
 
     @property
     def precision(self) -> Optional[float]:
@@ -882,6 +886,7 @@ class Minuit:
             t.value,
         )
         self._make_covariance()
+        self._merrors = mutil.MErrors()
 
         return self  # return self for method chaining and to autodisplay current state
 
@@ -1455,6 +1460,8 @@ class Minuit:
             edm_goal,
             t.value,
         )
+
+        self._merrors = mutil.MErrors()
 
         if accurate_covar:
             self._make_covariance()

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1213,6 +1213,16 @@ def test_errordef():
         m.errordef = 0
 
 
+def test_errordef_updates_covariance():
+    m = Minuit(lambda x: x**2, 0)
+    m.migrad()
+    assert_allclose(m.covariance[0, 0], 1)
+    m.errordef = 0.5
+    assert_allclose(m.errors["x"] ** 2, 0.5)
+    assert_allclose(m.covariance[0, 0], 0.5)
+    assert m.fmin.errordef == 0.5
+
+
 def test_print_level():
     from iminuit._core import MnPrint
 
@@ -1705,6 +1715,19 @@ def test_minos_new_min():
     # ...but interval is correct
     assert m.merrors["x"].lower == approx(-0.9, abs=1e-2)
     assert m.merrors["x"].upper == approx(1.1, abs=1e-2)
+
+
+@pytest.mark.parametrize("algorithm", ("migrad", "simplex", "scan"))
+def test_minos_cleared_by_new_minimization(algorithm):
+    m = Minuit(func0, x=0, y=0)
+    m.migrad()
+    m.minos()
+    assert len(m.merrors) == 2
+    assert m.params[0].merror is not None
+    m.values = (5, 5)
+    getattr(m, algorithm)()
+    assert len(m.merrors) == 0
+    assert m.params[0].merror is None
 
 
 def test_minos_without_migrad():

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -155,6 +155,17 @@ def test_scipy_fixed(grad):
         assert m.fmin.ngrad == 0
 
 
+def test_scipy_clears_merrors():
+    m = Minuit(fcn, a=1, b=2)
+    m.migrad()
+    m.minos()
+    assert len(m.merrors) == 2
+    m.values = (5, 5)
+    m.scipy()
+    assert len(m.merrors) == 0
+    assert m.params[0].merror is None
+
+
 @pytest.mark.parametrize("stra", (0, 1))
 @pytest.mark.parametrize("grad", (None, grad))
 def test_scipy_errordef(stra, grad):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`simplex()` and `scan()` clear `merrors`, but `migrad()` and `scipy()` did not. After `m.migrad(); m.minos(); m.values = (5, 5); m.migrad()`, `m.merrors` and `m.params[i].merror` still held the intervals of the old minimum. Both methods now clear `merrors`, so any new minimization drops them.

The `errordef` setter tells Minuit2 to rescale the parameter errors in the user state, but the separate `_covariance` copy stayed behind: after `m.migrad(); m.errordef = 0.5`, `m.errors[0]**2` was 0.5 while `m.covariance[0, 0]` was still 1.0. The setter now rebuilds the covariance when the state is still the one from the function minimum.

Part of #1192