### PR TITLE
fix: scipy() mutated options, misreported call limit, and stale covariance

### DIFF
--- a/src/iminuit/minuit.py
+++ b/src/iminuit/minuit.py
@@ -1325,7 +1325,7 @@ class Minuit:
             else:
                 method = "BFGS"
 
-        options = options or {}
+        options = dict(options or {})
 
         # attempt to set default number of function evaluations if not provided
         # various workarounds for API inconsistencies in scipy.optimize.minimize
@@ -1438,7 +1438,7 @@ class Minuit:
             r.fun,
             self.errordef,
             edm_goal,
-            self.nfcn,
+            r["nfev"],
             ncall,
             accurate_covar,
         )
@@ -1456,11 +1456,10 @@ class Minuit:
             t.value,
         )
 
-        if accurate_covar:
-            self._make_covariance()
+        if not accurate_covar and self.strategy.strategy > 0:
+            self.hesse()
         else:
-            if self.strategy.strategy > 0:
-                self.hesse()
+            self._make_covariance()
 
         return self
 

--- a/tests/test_scipy.py
+++ b/tests/test_scipy.py
@@ -303,3 +303,40 @@ def test_options():
     b_with_options = m.values["b"]
 
     assert b_without_options > b_with_options
+
+
+def test_options_not_modified():
+    m = Minuit(fcn, a=1, b=2)
+    opts = {"disp": False}
+    m.scipy(options=opts)
+    assert m.valid
+    assert opts == {"disp": False}
+
+
+def test_ncall_counts_only_current_run():
+    def rosen3(x):
+        return sum(100 * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2)
+
+    m = Minuit(rosen3, np.zeros(3))
+    m.errordef = 1
+    m.migrad()
+    nfcn_before = m.nfcn
+    assert nfcn_before > 100
+    m.strategy = 0
+    m.values = (0.9, 0.9, 0.9)
+    m.scipy(ncall=100)
+    assert m.valid
+    assert not m.fmin.has_reached_call_limit
+    assert m.fmin.nfcn == m.nfcn
+    assert m.fmin.nfcn > nfcn_before
+
+
+def test_covariance_updated_with_strategy_0():
+    m = Minuit(fcn, a=1, b=2)
+    m.migrad()
+    cov1 = np.array(m.covariance)
+    m.strategy = 0
+    m.values = (5, 5)
+    m.scipy()
+    assert m._last_state.has_covariance
+    assert not np.array_equal(np.array(m.covariance), cov1)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit.scipy()` had three related problems. It wrote `maxiter`, `maxfev`, or `maxfun` into the `options` dict that the caller passed in, so `opts = {"disp": False}; m.scipy(options=opts)` left `opts` with an extra `maxiter` key. It passed the cumulative call count `self.nfcn` to `FunctionMinimum`, so `m.migrad(); m.strategy = 0; m.scipy(ncall=100)` reported `has_reached_call_limit` and `valid == False` although the scipy run converged in about 75 calls. With `strategy == 0` and no exact Hessian, it did not update `self._covariance`, so `m.covariance` still showed the matrix from the previous `migrad()` call.

`options` is now copied before it is changed. `FunctionMinimum` receives `r["nfev"]`, the number of calls in this run; `FMin.nfcn` still reports the total, as for the other algorithms. `_make_covariance()` now runs whenever `hesse()` does not.

Part of #1192