### PR TITLE
fix: avoid NaN in binned chi2 gradients when mu is zero

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -285,9 +285,17 @@ def poisson_chi2(n: ArrayLike, mu: ArrayLike) -> float:
     return 2 * np.sum(n * (log_or_zero(n) - log_or_zero(mu)) + mu - n)
 
 
+def _n_over_mu_or_zero(n: NDArray, mu: NDArray) -> NDArray:
+    # log_or_zero is constant for mu <= 0, so the derivative vanishes in those bins
+    ma = mu > 0
+    r = np.zeros_like(mu * 1.0)
+    r[ma] = n[ma] / mu[ma]
+    return r
+
+
 def _poisson_chi2_grad(n: NDArray, mu: NDArray, gmu: NDArray) -> NDArray:
     assert gmu.ndim == 2
-    return 2 * np.sum((1.0 - n / mu) * gmu, axis=1)
+    return 2 * np.sum((1.0 - _n_over_mu_or_zero(n, mu)) * gmu, axis=1)
 
 
 def multinomial_chi2(n: ArrayLike, mu: ArrayLike) -> float:
@@ -319,7 +327,7 @@ def multinomial_chi2(n: ArrayLike, mu: ArrayLike) -> float:
 
 def _multinomial_chi2_grad(n: NDArray, mu: NDArray, gmu: NDArray) -> NDArray:
     assert gmu.ndim == 2
-    return -2 * np.sum(n / mu * gmu, axis=1)
+    return -2 * np.sum(_n_over_mu_or_zero(n, mu) * gmu, axis=1)
 
 
 def template_chi2_jsc(n: ArrayLike, mu: ArrayLike, mu_var: ArrayLike) -> float:

--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -287,10 +287,7 @@ def poisson_chi2(n: ArrayLike, mu: ArrayLike) -> float:
 
 def _n_over_mu_or_zero(n: NDArray, mu: NDArray) -> NDArray:
     # log_or_zero is constant for mu <= 0, so the derivative vanishes in those bins
-    ma = mu > 0
-    r = np.zeros_like(mu * 1.0)
-    r[ma] = n[ma] / mu[ma]
-    return r
+    return np.divide(n, mu, out=np.zeros_like(mu, dtype=float), where=mu > 0)
 
 
 def _poisson_chi2_grad(n: NDArray, mu: NDArray, gmu: NDArray) -> NDArray:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -751,6 +751,17 @@ def test_BinnedNLL_negative_weights(use_grad):
         assert m2.ngrad == 0
 
 
+def test_BinnedNLL_grad_with_zero_prediction():
+    # the expected counts underflow to zero in the tail bins
+    n = [48, 7, 0, 0, 0]
+    xe = np.array([0.0, 1.41453733, 2.82907465, 4.24361198, 5.6581493, 7.07268663])
+    c = BinnedNLL(n, xe, expon_cdf, grad=numerical_model_gradient(expon_cdf))
+
+    ref = numerical_cost_gradient(c)
+    for a in (0.1, 1):
+        assert_allclose(c.grad(a), ref(a))
+
+
 def test_BinnedNLL_name(binned):
     mle, nx, xe = binned
 
@@ -1105,11 +1116,13 @@ def test_ExtendedBinnedNLL_negative_weights(use_grad):
         w, xe, scaled_expon_cdf, grad=numerical_model_gradient(scaled_expon_cdf)
     )
 
-    # if use_grad:
-    #     ref = numerical_cost_gradient(c)
-    #     assert_allclose(c.grad(1, 0.1), ref(1, 0.1))
-    #     assert_allclose(c.grad(1, 1), ref(1, 1))
-    #     assert_allclose(c.grad(2, 12), ref(2, 12))
+    if use_grad:
+        ref = numerical_cost_gradient(c)
+        # the prediction underflows to zero in the tail bins, which makes the
+        # numerical reference gradient inaccurate
+        assert_allclose(c.grad(1, 0.1), ref(1, 0.1), rtol=1e-4)
+        assert_allclose(c.grad(1, 1), ref(1, 1))
+        assert_allclose(c.grad(2, 12), ref(2, 12))
 
     m2 = Minuit(c, 50, 1, grad=use_grad)
     m2.limits = (0, None)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`_poisson_chi2_grad` and `_multinomial_chi2_grad` computed `n / mu` without a guard. If the model prediction underflows to exactly zero in a bin, this gives NaN or inf and the whole gradient becomes NaN with a RuntimeWarning. For example, `ExtendedBinnedNLL` with an exponential CDF at a small scale returns `[nan, nan]` from `grad`.

The value functions use `log_or_zero`, which is constant for `mu <= 0`, so the consistent derivative of the log term in such bins is zero. Both gradients now use a helper that evaluates `n / mu` only where `mu > 0`. The previously commented-out gradient checks in `test_ExtendedBinnedNLL_negative_weights` are restored, and a new test covers the multinomial path.

Part of #1192