### PR TITLE
fix: honor throw_nan for numba cfunc cost functions

### DIFF
--- a/src/fcn.cpp
+++ b/src/fcn.cpp
@@ -80,7 +80,7 @@ double FCN::operator()(const std::vector<double>& x) const {
   ++nfcn_;
   if (array_call_) {
     if (cfcn_) {
-      return cfcn_(x.size(), x.data());
+      return check_value(cfcn_(x.size(), x.data()), x);
     } else {
       py::array_t<double> a(static_cast<py::ssize_t>(x.size()), x.data());
       return check_value(as_double(fcn_(a)), x);

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1601,6 +1601,27 @@ def test_cfunc():
     assert_allclose(m.values, (0, 1, 2), atol=1e-8)
 
 
+def test_cfunc_throw_nan():
+    nb = pytest.importorskip("numba")
+
+    c_sig = nb.types.double(nb.types.uintc, nb.types.CPointer(nb.types.double))
+
+    @nb.cfunc(c_sig)
+    def fcn(n, x):
+        return np.nan
+
+    m = Minuit(fcn, (1, 2))
+    assert m._fcn._cfcn is True
+    m.migrad()
+    assert m.nfcn > 0
+
+    m.reset()
+    m.throw_nan = True
+    with pytest.raises(RuntimeError, match="result is NaN"):
+        m.migrad()
+    assert m.nfcn > 0
+
+
 @pytest.mark.parametrize("cl", (0.5, None, 0.9))
 @pytest.mark.parametrize("experimental", (False, True))
 def test_confidence_level(cl, experimental):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`FCN::operator()` had a fast path for numba `cfunc` cost functions that returned the value without a check. A `cfunc` that returns NaN did not raise with `m.throw_nan = True`, and no NaN warning was printed, unlike the Python calling conventions.

The cfunc result now goes through `check_value`, the same as the other paths. A regression test covers both the raise and the call counter.

Part of #1192