### PR TITLE
fix: copy input arrays in cost constructors

### DIFF
--- a/src/iminuit/cost.py
+++ b/src/iminuit/cost.py
@@ -809,7 +809,8 @@ class MaskedCost(Cost):
         verbose: int,
     ):
         """For internal use."""
-        self._data = data
+        # copy, since the setters write into this array
+        self._data = data.copy()
         self._mask = None
         self._update_cache()
         Cost.__init__(self, parameters, verbose)
@@ -2455,13 +2456,14 @@ class NormalConstraint(Cost):
         """
         tp_args = (args,) if isinstance(args, str) else tuple(args)
         nargs = len(tp_args)
-        self._expected = _norm(value)
+        # copy, since the setters write into these arrays
+        self._expected = _norm(value).copy()
         if self._expected.ndim > 1:
             raise ValueError("value must be a scalar or one-dimensional")
         # args can be a vector of values, in this case we have nargs == 1
         if nargs > 1 and len(self._expected) != nargs:
             raise ValueError("size of value does not match size of args")
-        self._cov = _norm(error)
+        self._cov = _norm(error).copy()
         if len(self._cov) != len(self._expected):
             raise ValueError("size of error does not match size of value")
         if self._cov.ndim < 2:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1906,6 +1906,55 @@ def test_NormalConstraint_pickle():
     assert_equal(c.covariance, c2.covariance)
 
 
+def test_NormalConstraint_does_not_modify_inputs():
+    value = np.array([1.0, 2.0])
+    error = np.array([3.0, 4.0])
+
+    c = NormalConstraint(("a", "b"), value, error)
+    assert_equal(value, [1.0, 2.0])
+    assert_equal(error, [3.0, 4.0])
+
+    c.value = [5.0, 6.0]
+    c.covariance = [7.0, 8.0]
+    assert_equal(value, [1.0, 2.0])
+    assert_equal(error, [3.0, 4.0])
+
+
+def test_NormalConstraint_does_not_modify_inputs_2d():
+    value = np.array([1.0, 2.0])
+    cov = 2 * np.eye(2)
+
+    c = NormalConstraint(("a", "b"), value, cov)
+    assert_equal(cov, 2 * np.eye(2))
+
+    c.covariance = 3 * np.eye(2)
+    assert_equal(value, [1.0, 2.0])
+    assert_equal(cov, 2 * np.eye(2))
+
+
+def test_UnbinnedNLL_does_not_modify_inputs():
+    x = np.array([1.0, 2.0, 3.0])
+
+    c = UnbinnedNLL(x, norm_pdf)
+    assert_equal(x, [1.0, 2.0, 3.0])
+
+    c.data = [4.0, 5.0, 6.0]
+    assert_equal(x, [1.0, 2.0, 3.0])
+
+
+@pytest.mark.parametrize("Cost", (BinnedNLL, ExtendedBinnedNLL))
+def test_BinnedNLL_does_not_modify_inputs(Cost):
+    n = np.array([1.0, 2.0])
+    xe = np.array([0.0, 1.0, 2.0])
+
+    c = Cost(n, xe, norm_cdf)
+    assert_equal(n, [1.0, 2.0])
+
+    c.n = [3.0, 4.0]
+    assert_equal(n, [1.0, 2.0])
+    assert_equal(xe, [0.0, 1.0, 2.0])
+
+
 def test_model_wrong_shape_int_output():
     # a model that returns an integer sequence with the wrong shape must still
     # raise the shape error instead of slipping through the float early-return


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Cost objects kept a reference to the arrays given by the user and then wrote into them. `err = np.array([1.0, 2.0]); NormalConstraint(["a", "b"], [0, 0], err)` left `err` as `[1., 4.]`, because the constructor squares the error array in place. In the same way, `x = np.array([1., 2., 3.]); c = UnbinnedNLL(x, pdf); c.data = [4, 5, 6]` changed `x`.

The constructors of `NormalConstraint` and `MaskedCost` now copy the arrays. `Template` already did this.

Part of #1192