### PR TITLE
fix: keep the seed gradient when hesse runs without a minimum

### DIFF
--- a/src/functionminimum_extra.cpp
+++ b/src/functionminimum_extra.cpp
@@ -42,7 +42,10 @@ FunctionMinimum init(const FCN& fcn, const MnUserParameterState& st,
   }
 
   MinimumParameters minp(val, err, seed.Fval());
-  std::vector<MinimumState> minstv(1, MinimumState(minp, seed.Edm(), fcn.nfcn_));
+  // keep the seed gradient; MnHesse uses its step sizes to start the numerical
+  // second derivatives, an empty gradient makes them collapse to near zero
+  std::vector<MinimumState> minstv(
+      1, MinimumState(minp, MinimumError(n), seed.Gradient(), seed.Edm(), fcn.nfcn_));
   if (minstv.back().Edm() < edm_goal) return FunctionMinimum(seed, minstv, fcn.Up());
   return FunctionMinimum(seed, minstv, fcn.Up(), FunctionMinimum::MnAboveMaxEdm);
 }

--- a/src/functionminimum_extra.cpp
+++ b/src/functionminimum_extra.cpp
@@ -42,8 +42,6 @@ FunctionMinimum init(const FCN& fcn, const MnUserParameterState& st,
   }
 
   MinimumParameters minp(val, err, seed.Fval());
-  // keep the seed gradient; MnHesse uses its step sizes to start the numerical
-  // second derivatives, an empty gradient makes them collapse to near zero
   std::vector<MinimumState> minstv(
       1, MinimumState(minp, MinimumError(n), seed.Gradient(), seed.Edm(), fcn.nfcn_));
   if (minstv.back().Edm() < edm_goal) return FunctionMinimum(seed, minstv, fcn.Up());

--- a/tests/test_minuit.py
+++ b/tests/test_minuit.py
@@ -1355,6 +1355,29 @@ def test_hesse_without_migrad():
     assert m.fmin.hesse_failed
 
 
+def test_hesse_without_migrad_nonzero_fval():
+    # f(x) at the start value is not zero, Hesse needs a proper step size
+    m = Minuit(lambda x: (x - 1) ** 2, x=0)
+    m.errordef = Minuit.LEAST_SQUARES
+    m.hesse()
+    assert not m.fmin.hesse_failed
+    assert m.covariance is not None
+    assert m.errors["x"] == approx(1.0, abs=1e-4)
+    assert m.fmin.nfcn > 0
+
+
+def test_hesse_after_modifying_values():
+    m = Minuit(lambda x, y: (x - 1) ** 2 + (y - 2) ** 2, x=0, y=0)
+    m.errordef = Minuit.LEAST_SQUARES
+    m.migrad()
+    m.values["x"] = 0
+    m.hesse()
+    assert not m.fmin.hesse_failed
+    assert m.covariance is not None
+    assert m.errors["x"] == approx(1.0, abs=1e-4)
+    assert m.errors["y"] == approx(1.0, abs=1e-4)
+
+
 def test_edm_goal():
     m = Minuit(func0, x=0, y=0)
     m.migrad()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Minuit(lambda x: (x - 1) ** 2, x=0).hesse()` set `hesse_failed` and gave no covariance. The same happened after `migrad()` when the user set a parameter back to 0 and called `hesse()`. The `init` function in `functionminimum_extra.cpp` built the `MinimumState` with an empty `FunctionGradient`, so `MnHesse` started from zero step sizes, which it clamps to about 3e-14 at a parameter value of 0. The fix passes `seed.Gradient()` into the `MinimumState`; `MinimumError(n)` stays unset so no covariance is claimed. With this change a user-supplied `hessian=` callable also takes the analytical path in this case (`nhessian > 0`).

Part of #1192