### PR TITLE
fix: make the MnPrint bindings memory-safe

### DIFF
--- a/src/print.cpp
+++ b/src/print.cpp
@@ -7,34 +7,49 @@ using namespace ROOT::Minuit2;
 using cstr = const char*;
 using namespace pybind11::literals;
 
-// MnPrint stores the prefix as a `const char*` and keeps it on a stack for its
-// whole lifetime. We therefore must keep the prefix string alive as long as the
-// MnPrint object exists. This holder owns the string; since members are
-// destroyed in reverse order of declaration, `print` is destroyed before
-// `prefix`, so the pointer stays valid for MnPrint's lifetime.
+// MnPrint pushes the prefix pointer on a thread-local stack in its constructor
+// and pops it in its destructor. Python destroys objects in arbitrary order and
+// possibly in another thread, so we cannot hold an MnPrint member. Instead we
+// store prefix and level and make a local MnPrint for each message, which
+// keeps the push/pop properly nested.
 struct PyMnPrint {
   std::string prefix;
-  MnPrint print;
+  int level;
 
-  PyMnPrint(std::string p, int level)
-      : prefix(std::move(p)), print(prefix.c_str(), level) {}
+  PyMnPrint(std::string p, int l) : prefix(std::move(p)), level(l) {}
 };
 
 void bind_print(py::module m) {
   py::class_<PyMnPrint>(m, "MnPrint")
 
       .def(py::init<std::string, int>(), "prefix"_a, "level"_a)
-      .def("error", [](PyMnPrint& self, cstr msg) { self.print.Error(msg); })
-      .def("warn", [](PyMnPrint& self, cstr msg) { self.print.Warn(msg); })
-      .def("info", [](PyMnPrint& self, cstr msg) { self.print.Info(msg); })
-      .def("debug", [](PyMnPrint& self, cstr msg) { self.print.Debug(msg); })
+      .def("error",
+           [](PyMnPrint& self, cstr msg) {
+             MnPrint print(self.prefix.c_str(), self.level);
+             print.Error(msg);
+           })
+      .def("warn",
+           [](PyMnPrint& self, cstr msg) {
+             MnPrint print(self.prefix.c_str(), self.level);
+             print.Warn(msg);
+           })
+      .def("info",
+           [](PyMnPrint& self, cstr msg) {
+             MnPrint print(self.prefix.c_str(), self.level);
+             print.Info(msg);
+           })
+      .def("debug",
+           [](PyMnPrint& self, cstr msg) {
+             MnPrint print(self.prefix.c_str(), self.level);
+             print.Debug(msg);
+           })
       .def_property_static(
           "global_level", [](py::object) { return MnPrint::GlobalLevel(); },
           [](py::object, int x) { MnPrint::SetGlobalLevel(x); })
 
-      .def("show_prefix_stack", &MnPrint::ShowPrefixStack)
-      .def("add_filter", &MnPrint::AddFilter)
-      .def("clear_filter", &MnPrint::ClearFilter)
+      .def_static("show_prefix_stack", &MnPrint::ShowPrefixStack)
+      .def_static("add_filter", &MnPrint::AddFilter)
+      .def_static("clear_filter", &MnPrint::ClearFilter)
 
       ;
 }

--- a/src/printimpl.cpp
+++ b/src/printimpl.cpp
@@ -4,7 +4,7 @@
 using ROOT::Minuit2::MnPrint;
 
 void MnPrint::Impl(MnPrint::Verbosity level, const std::string& s) {
-  const char* label[4] = {"E", "W", "I", "D"};
+  const char* label[5] = {"E", "W", "I", "D", "T"};
   const int ilevel = static_cast<int>(level);
   pybind11::print(label[ilevel], s);
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -160,6 +160,49 @@ def test_MnPrint_prefix():
         MnPrint.global_level = prev
 
 
+def test_MnPrint_out_of_order_destruction(capsys):
+    # MnPrint pushes the prefix on a thread-local stack; Python can destroy the
+    # objects in any order, so each object must own its prefix
+    prev = MnPrint.global_level
+    try:
+        MnPrint.global_level = 3
+        a = MnPrint("AAA", 3)
+        b = MnPrint("BBB", 3)
+        del a
+        MnPrint.show_prefix_stack(True)
+        b.warn("hi")
+    finally:
+        MnPrint.show_prefix_stack(False)
+        MnPrint.global_level = prev
+
+    captured = capsys.readouterr().out
+    assert "BBB" in captured
+    assert "hi" in captured
+    assert "AAA" not in captured
+
+
+def test_MnPrint_static_methods():
+    p = MnPrint("some_prefix", 1)
+    # these are static methods, but must also work on an instance
+    p.show_prefix_stack(False)
+    p.add_filter("some_prefix")
+    p.clear_filter()
+
+
+def test_MnPrint_trace_level(capsys):
+    from iminuit import Minuit
+
+    m = Minuit(lambda x: (x - 1) ** 2, x=0)
+    m.print_level = 4
+    try:
+        m.migrad()
+    finally:
+        m.print_level = 0
+
+    assert m.valid
+    assert capsys.readouterr().out != ""
+
+
 def test_MnMigrad():
     fcn = FCN(fn, None, None, None, False, 1)
     state = MnUserParameterState()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Three problems in the `MnPrint` bindings. `MnPrint::Impl` indexed a four-element label array with the verbosity level, but `Verbosity` has a fifth level `Trace = 4`, which `MnLineSearch` and `InitialGradientCalculator` emit; `Minuit(lambda x: (x - 1) ** 2, x=0)` with `print_level = 4` read a garbage pointer and crashed. `PyMnPrint` held an `MnPrint` member, whose constructor and destructor push and pop a thread-local stack of raw prefix pointers, so out-of-order destruction in Python (`a = MnPrint("AAA", 3); b = MnPrint("BBB", 3); del a`) made `b.warn(...)` print the freed prefix of `a`. `show_prefix_stack`, `add_filter`, and `clear_filter` are static C++ functions, but were bound with `def`, so an instance call raised `TypeError`.

The fix adds the fifth label, stores only the prefix and level in `PyMnPrint` and makes a local `MnPrint` for each message so the push and pop stay nested, and binds the three static functions with `def_static`. The Python API does not change. Regression tests are in `tests/test_core.py`.

Part of #1192