### PR TITLE
fix: check indices in MnUserParameterState and MnUserTransformation

### DIFF
--- a/src/usercovariance.cpp
+++ b/src/usercovariance.cpp
@@ -16,8 +16,15 @@ bool operator==(const MnUserCovariance& a, const MnUserCovariance& b) {
 namespace py = pybind11;
 using namespace ROOT::Minuit2;
 
+MnUserCovariance make_covariance(std::vector<double> data, unsigned n) {
+  // Minuit2 does not check this and then reads past the end of the data
+  if (data.size() != n * (n + 1) / 2)
+    throw py::value_error("data length does not match n * (n + 1) / 2");
+  return MnUserCovariance{std::move(data), n};
+}
+
 MnUserCovariance init(py::sequence seq, unsigned n) {
-  return MnUserCovariance{py::cast<std::vector<double>>(seq), n};
+  return make_covariance(py::cast<std::vector<double>>(seq), n);
 }
 
 void bind_usercovariance(py::module m) {
@@ -45,8 +52,10 @@ void bind_usercovariance(py::module m) {
             return py::make_tuple(self.Data(), self.Nrow());
           },
           [](py::tuple tp) {
-            return MnUserCovariance(tp[0].cast<std::vector<double>>(),
-                                    tp[1].cast<double>());
+            if (tp.size() != 2)
+              throw std::runtime_error("MnUserCovariance invalid state");
+            return make_covariance(tp[0].cast<std::vector<double>>(),
+                                   tp[1].cast<unsigned>());
           }))
 
       ;

--- a/src/userparameterstate.cpp
+++ b/src/userparameterstate.cpp
@@ -27,11 +27,16 @@ int size(const MnUserParameterState& self) {
   return static_cast<int>(self.MinuitParameters().size());
 }
 
-const MinuitParameter& getitem(const MnUserParameterState& self, int i) {
+// Minuit2 only asserts on the index, which is compiled out in release builds
+unsigned index(const MnUserParameterState& self, int i) {
   const int n = size(self);
   if (i < 0) i += n;
   if (i < 0 || i >= n) throw py::index_error();
-  return self.Parameter(i);
+  return static_cast<unsigned>(i);
+}
+
+const MinuitParameter& getitem(const MnUserParameterState& self, int i) {
+  return self.Parameter(index(self, i));
 }
 
 auto iter(const MnUserParameterState& self) {
@@ -73,20 +78,21 @@ void bind_userparameterstate(py::module m) {
                       &MnUserParameterState::Add))
       .def("add", py::overload_cast<const std::string&, double, double, double, double>(
                       &MnUserParameterState::Add))
-      .def("fix", py::overload_cast<unsigned>(&MnUserParameterState::Fix))
-      .def("release", py::overload_cast<unsigned>(&MnUserParameterState::Release))
-      .def("set_value",
-           py::overload_cast<unsigned, double>(&MnUserParameterState::SetValue))
-      .def("set_error",
-           py::overload_cast<unsigned, double>(&MnUserParameterState::SetError))
-      .def("set_limits", py::overload_cast<unsigned, double, double>(
-                             &MnUserParameterState::SetLimits))
-      .def("set_upper_limit",
-           py::overload_cast<unsigned, double>(&MnUserParameterState::SetUpperLimit))
-      .def("set_lower_limit",
-           py::overload_cast<unsigned, double>(&MnUserParameterState::SetLowerLimit))
+      .def("fix", [](MnUserParameterState& self, int i) { self.Fix(index(self, i)); })
+      .def("release",
+           [](MnUserParameterState& self, int i) { self.Release(index(self, i)); })
+      .def("set_value", [](MnUserParameterState& self, int i,
+                           double x) { self.SetValue(index(self, i), x); })
+      .def("set_error", [](MnUserParameterState& self, int i,
+                           double x) { self.SetError(index(self, i), x); })
+      .def("set_limits", [](MnUserParameterState& self, int i, double a,
+                            double b) { self.SetLimits(index(self, i), a, b); })
+      .def("set_upper_limit", [](MnUserParameterState& self, int i,
+                                 double x) { self.SetUpperLimit(index(self, i), x); })
+      .def("set_lower_limit", [](MnUserParameterState& self, int i,
+                                 double x) { self.SetLowerLimit(index(self, i), x); })
       .def("remove_limits",
-           py::overload_cast<unsigned>(&MnUserParameterState::RemoveLimits))
+           [](MnUserParameterState& self, int i) { self.RemoveLimits(index(self, i)); })
       .def_property_readonly("fval", &MnUserParameterState::Fval)
       .def_property_readonly("edm", &MnUserParameterState::Edm)
       .def_property_readonly("covariance", &MnUserParameterState::Covariance)

--- a/src/usertransformation.cpp
+++ b/src/usertransformation.cpp
@@ -30,10 +30,23 @@ auto iter(const MnUserTransformation& self) {
   return py::make_iterator(self.Parameters().begin(), self.Parameters().end());
 }
 
+// Minuit2 only asserts on the index, which is compiled out in release builds
+unsigned ext_index(const MnUserTransformation& self, int i) {
+  const int n = size(self);
+  if (i < 0) i += n;
+  if (i < 0 || i >= n) throw py::index_error();
+  return static_cast<unsigned>(i);
+}
+
+unsigned int_index(const MnUserTransformation& self, int i) {
+  const int n = static_cast<int>(self.VariableParameters());
+  if (i < 0) i += n;
+  if (i < 0 || i >= n) throw py::index_error();
+  return static_cast<unsigned>(i);
+}
+
 const auto& getitem(const MnUserTransformation& self, int i) {
-  if (i < 0) i += size(self);
-  if (i < 0 || i >= size(self)) throw py::index_error();
-  return self.Parameter(i);
+  return self.Parameter(ext_index(self, i));
 }
 
 void bind_usertransformation(py::module m) {
@@ -41,13 +54,21 @@ void bind_usertransformation(py::module m) {
 
       .def(py::init<>())
 
-      .def("name", &MnUserTransformation::GetName)
+      .def("name",
+           [](const MnUserTransformation& self, int i) -> const std::string& {
+             return self.GetName(ext_index(self, i));
+           })
       .def("index", &MnUserTransformation::FindIndex)
-      .def("ext2int", &MnUserTransformation::Ext2int)
-      .def("int2ext", &MnUserTransformation::Int2ext)
-      .def("dint2ext", &MnUserTransformation::DInt2Ext)
-      .def("ext_of_int", &MnUserTransformation::ExtOfInt)
-      .def("int_of_ext", &MnUserTransformation::IntOfExt)
+      .def("ext2int", [](const MnUserTransformation& self, int i,
+                         double x) { return self.Ext2int(ext_index(self, i), x); })
+      .def("int2ext", [](const MnUserTransformation& self, int i,
+                         double x) { return self.Int2ext(int_index(self, i), x); })
+      .def("dint2ext", [](const MnUserTransformation& self, int i,
+                          double x) { return self.DInt2Ext(int_index(self, i), x); })
+      .def("ext_of_int", [](const MnUserTransformation& self,
+                            int i) { return self.ExtOfInt(int_index(self, i)); })
+      .def("int_of_ext", [](const MnUserTransformation& self,
+                            int i) { return self.IntOfExt(ext_index(self, i)); })
       .def_property_readonly("variable_parameters",
                              &MnUserTransformation::VariableParameters)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,75 @@ def test_MnUserParameterState():
             st[bad]
 
 
+def test_MnUserCovariance_bad_length():
+    # data length must match n * (n + 1) / 2, else reads run past the end
+    with pytest.raises(ValueError):
+        MnUserCovariance((1.0,), 3)
+    with pytest.raises(ValueError):
+        MnUserCovariance((1, 2, 3, 4), 2)
+
+
+@pytest.mark.parametrize(
+    "method,args",
+    [
+        ("fix", ()),
+        ("release", ()),
+        ("remove_limits", ()),
+        ("set_value", (1.0,)),
+        ("set_error", (0.5,)),
+        ("set_limits", (0.0, 2.0)),
+        ("set_upper_limit", (2.0,)),
+        ("set_lower_limit", (0.0,)),
+    ],
+)
+def test_MnUserParameterState_setter_index(method, args):
+    st = MnUserParameterState()
+    st.add("x", 1, 0.1)
+
+    # valid negative index works
+    getattr(st, method)(-1, *args)
+
+    # out-of-range indices raise IndexError instead of crashing (SIGBUS)
+    for bad in (-2, 1, 5):
+        with pytest.raises(IndexError):
+            getattr(st, method)(bad, *args)
+
+
+def test_MnUserTransformation_index():
+    st = MnUserParameterState()
+    st.add("x", 1, 0.1, 0, 2)
+    st.add("y", 1, 0.1)
+    st.fix(1)
+    tr = st.trafo
+
+    assert len(tr) == 2
+    assert tr.variable_parameters == 1
+
+    # external indices
+    assert tr.name(-1) == "y"
+    tr.ext2int(0, 1.0)
+    assert tr.int_of_ext(0) == 0
+    for bad in (-3, 2, 5):
+        with pytest.raises(IndexError):
+            tr.name(bad)
+        with pytest.raises(IndexError):
+            tr.ext2int(bad, 1.0)
+        with pytest.raises(IndexError):
+            tr.int_of_ext(bad)
+
+    # internal indices, only one parameter is free
+    tr.int2ext(0, 0.0)
+    tr.dint2ext(0, 0.0)
+    assert tr.ext_of_int(-1) == 0
+    for bad in (-2, 1, 5):
+        with pytest.raises(IndexError):
+            tr.int2ext(bad, 0.0)
+        with pytest.raises(IndexError):
+            tr.dint2ext(bad, 0.0)
+        with pytest.raises(IndexError):
+            tr.ext_of_int(bad)
+
+
 def test_MnUserParameterState_limit_equality():
     # parameters/states differing only in their limit values must not compare equal
     a = MnUserParameterState()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Several `_core` methods passed the index straight to Minuit2, which only `assert()`s on it. Asserts are compiled out in release builds, so an out-of-range index read or wrote out of bounds: `MnUserParameterState().add("x", 1, 0.1); st.fix(5)` killed the interpreter with SIGBUS.

The index-taking methods of `MnUserParameterState` and `MnUserTransformation` now take a signed index, accept negative indices like `__getitem__` does, and raise `IndexError` otherwise. `MnUserTransformation` separates external indices from internal ones, which are bounded by `variable_parameters`. `MnUserCovariance` raises `ValueError` if the data length does not match `n * (n + 1) / 2`; before, `MnUserCovariance([1.0], 3)[2, 2]` returned heap garbage.

The Python `Minuit` API is unchanged.

Part of #1192