### PR TITLE
feat(docs): add llms.txt and Markdown page versions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,14 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
+    "sphinx_llm.txt",
 ]
+
+# The default is the full README, which is too long for the summary block
+llms_txt_description = (
+    "Documentation of iminuit, a Jupyter-friendly Python interface to the"
+    " Minuit2 C++ minimizer, with cost functions for likelihood fits."
+)
 
 nbsphinx_kernel_name = "python3"
 nbsphinx_execute_arguments = [
@@ -63,7 +70,8 @@ autodoc_type_aliases = {"ArrayLike": "ArrayLike"}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "_themes"]
+# interactive_demo.ipynb is only the source for a gif, not a page
+exclude_patterns = ["_build", "_themes", "_static/interactive_demo.ipynb"]
 
 # html_logo = "_static/iminuit_logo.svg"
 

--- a/doc/index.rst.in
+++ b/doc/index.rst.in
@@ -1,3 +1,7 @@
+.. meta::
+   :description: iminuit is a Jupyter-friendly Python interface to the Minuit2
+      C++ minimizer, with built-in cost functions for likelihood fits.
+
 .. include:: bibliography.txt
 
 .. toctree::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ doc = [
     "jax",
     "jaxlib",
     "pytest-xdist",
+    "sphinx-llm",
 ]
 dev = [{ include-group = "test" }, { include-group = "doc" }]
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Ports scikit-hep/uhi#252. Adds LLM-friendly docs output with NVIDIA's `sphinx-llm` (`sphinx_llm.txt` extension). It runs the markdown builder alongside the HTML build and merges the results, so it is one extension and one build:

- `llms.txt` — sitemap with a one-line description per page.
- `llms-full.txt` — all docs in one file.
- `<page>.html.md` next to each `<page>.html`.

`llms_txt_description` is set because the default summary is the full README, and `index.rst.in` gets a `meta` description for the index page entry.

`doc/_static/interactive_demo.ipynb` is now excluded. It is only the source for a gif, but nbsphinx built it as an orphan page, which showed up in `llms.txt`.